### PR TITLE
feat: Add PerformanceTestRunnerPageComponent

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -22,6 +22,7 @@ import {DownloadTesterComponent} from './pages/download-tester/download-tester.c
 import {ProofreaderApiComponent} from './pages/built-in-ai-apis/proofreader-api/proofreader-api.component';
 import {AutocompleteComponent} from './pages/built-in-ai-apis/autocomplete/autocomplete.component';
 import {PerformanceHistoryComponent} from './pages/performance/performance-history/performance-history.component';
+import {PerformanceTestRunnerPageComponent} from './pages/performance/performance-test-runner/performance-test-runner.component';
 // @end
 
 const layouts: Routes = [
@@ -67,6 +68,10 @@ const layouts: Routes = [
       {
         path: "history",
         component: PerformanceHistoryComponent,
+      },
+      {
+        path: "perf-test-runner",
+        component: PerformanceTestRunnerPageComponent,
       }
     ]
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -57,6 +57,7 @@ import {ExecutionPerformanceComponent} from './components/execution-performance/
 import {PerformanceResultManager} from './managers/performance-result.manager';
 import {PerformanceHistoryComponent} from './pages/performance/performance-history/performance-history.component';
 import {MinutesAgoPipe} from './pipes/minutes-ago.pipe';
+import {PerformanceTestRunnerPageComponent} from './pages/performance/performance-test-runner/performance-test-runner.component';
 
 @NgModule({
   declarations: [
@@ -87,6 +88,7 @@ import {MinutesAgoPipe} from './pipes/minutes-ago.pipe';
     IndexComponent,
     LanguageDetectorComponent,
     PerformanceHistoryComponent,
+    PerformanceTestRunnerPageComponent,
     PromptApiComponent,
     ProofreaderApiComponent,
     RewriterApiComponent,

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -105,6 +105,12 @@
               <span>Performance History</span>
             </a>
           </li>
+          <li class="navigation-item" [class.active]="this.currentRoute === RouteEnum.PerformanceTestRunner">
+            <a class="btn" routerLink="/performance/perf-test-runner">
+              <i class="bi bi-speedometer2"></i>
+              <span>Performance Test Runner</span>
+            </a>
+          </li>
 
         @if(Environment.name !== EnvironmentNameEnum.ChromeDev) {
           <li class="navigation-item" [class.active]="this.currentRoute === RouteEnum.DownloadTester">

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -80,6 +80,8 @@ export class SidebarComponent extends BaseComponent implements OnInit {
       this.currentRoute = RouteEnum.Autocomplete;
     }else if(url.endsWith('performance/history')) {
       this.currentRoute = RouteEnum.PerformanceHistory;
+    }else if(url.endsWith('performance/perf-test-runner')) {
+      this.currentRoute = RouteEnum.PerformanceTestRunner;
     }else if(url.endsWith('/')) {
       this.currentRoute = RouteEnum.Home;
     }

--- a/src/app/enums/route.enum.ts
+++ b/src/app/enums/route.enum.ts
@@ -9,6 +9,7 @@ export enum RouteEnum {
   Autocomplete = 'autocomplete',
   SummarizerApi = 'summarizer-api',
   PromptApi = 'prompt-api',
+  PerformanceTestRunner = 'performance/perf-test-runner',
   // @start-remove-in-chrome-dev
   AudioMultimodalPromptApi = 'audio-multimodal-prompt-api',
   TranscriptionAudioMultimodalPromptApi = 'transcription-audio-multimodal-prompt-api',

--- a/src/app/pages/performance/performance-test-runner/performance-test-runner.component.html
+++ b/src/app/pages/performance/performance-test-runner/performance-test-runner.component.html
@@ -1,0 +1,1 @@
+<p>Performance Test Runner Page Works!</p>

--- a/src/app/pages/performance/performance-test-runner/performance-test-runner.component.ts
+++ b/src/app/pages/performance/performance-test-runner/performance-test-runner.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-performance-test-runner',
+  templateUrl: './performance-test-runner.component.html',
+  styleUrls: ['./performance-test-runner.component.scss']
+})
+export class PerformanceTestRunnerPageComponent { }

--- a/src/app/pages/performance/performance-test-runner/performance-test-runner.component.ts
+++ b/src/app/pages/performance/performance-test-runner/performance-test-runner.component.ts
@@ -3,6 +3,7 @@ import { Component } from '@angular/core';
 @Component({
   selector: 'app-performance-test-runner',
   templateUrl: './performance-test-runner.component.html',
-  styleUrls: ['./performance-test-runner.component.scss']
+  styleUrls: ['./performance-test-runner.component.scss'],
+  standalone: false,
 })
 export class PerformanceTestRunnerPageComponent { }


### PR DESCRIPTION
Adds a new page component PerformanceTestRunnerPageComponent accessible at the route /performance/perf-test-runner.

The component is a basic placeholder and does not include any tests as per your requirements.