### PR TITLE
Refactor: Rename ExecutionPerformanceResultBase to InferenceExecution…

### DIFF
--- a/src/app/models/execution-performance-result.model.ts
+++ b/src/app/models/execution-performance-result.model.ts
@@ -1,7 +1,7 @@
 import {BuiltInAiApiEnum} from '../enums/built-in-ai-api.enum';
-import {ExecutionPerformanceResultBase} from '../../performance-test/interfaces/execution-performance-result.base';
+import {InferenceExecutionResult} from '../../performance-test/interfaces/inference-execution-result';
 
-export class ExecutionPerformanceResultModel extends ExecutionPerformanceResultBase {
+export class ExecutionPerformanceResultModel extends InferenceExecutionResult {
   createdAt = new Date();
 
   api: BuiltInAiApiEnum;

--- a/src/performance-test/interfaces/inference-execution-result.ts
+++ b/src/performance-test/interfaces/inference-execution-result.ts
@@ -1,4 +1,4 @@
-export class ExecutionPerformanceResultBase {
+export class InferenceExecutionResult {
   sessionCreationStartedAt?: Date;
   sessionCreationEndedAt?: Date;
 

--- a/src/performance-test/models/performance-test-result.model.ts
+++ b/src/performance-test/models/performance-test-result.model.ts
@@ -1,9 +1,9 @@
 import {v4 as uuid} from 'uuid';
 import {PerformanceTestSeriesEnum} from '../../app/enums/performance-test-series.enum';
-import {ExecutionPerformanceResultBase} from '../interfaces/execution-performance-result.base';
+import {InferenceExecutionResult} from '../interfaces/inference-execution-result';
 import {ExecutionEnum} from '../enums/execution.enum';
 
-export class PerformanceTestResultModel extends ExecutionPerformanceResultBase {
+export class PerformanceTestResultModel extends InferenceExecutionResult {
   id: string = uuid();
   series: PerformanceTestSeriesEnum;
   status: ExecutionEnum = ExecutionEnum.Idle;


### PR DESCRIPTION
…Result

I've renamed ExecutionPerformanceResultBase to InferenceExecutionResult and updated all its references. The filename was also changed from execution-performance-result.base.ts to inference-execution-result.ts. This change improves clarity and consistency in naming.