### PR TITLE
Add 'Batch Executions' text label to sidebar

### DIFF
--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -75,6 +75,10 @@
       </li>
 
       <li class="navigation-category">
+        <i class="bi bi-tools"></i> <span>Batch Executions</span>
+      </li>
+
+      <li class="navigation-category">
         <i class="bi bi-window-desktop"></i> <span>Use Cases</span>
 
         <ul class="list-unstyled">


### PR DESCRIPTION
This change adds a new non-clickable category header 'Batch Executions' to the main navigation sidebar.