### PR TITLE
feat: Add SummarizerBatchPageComponent

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -8,6 +8,9 @@ import {IndexComponent} from './pages/index/index.component';
 import {LayoutComponent} from './components/layout/layout.component';
 import {WriterApiComponent} from './pages/built-in-ai-apis/writer-api/writer-api.component';
 import {SummarizerApiComponent} from './pages/built-in-ai-apis/summarizer-api/summarizer-api.component';
+import {
+  SummarizerBatchApiComponent
+} from './pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component';
 import {RewriterApiComponent} from './pages/built-in-ai-apis/rewriter-api/rewriter-api.component';
 import {Environment} from './environments/environment';
 // @start-remove-in-chrome-dev
@@ -39,6 +42,10 @@ const layouts: Routes = [
   {
     path: "summarizer-api",
     component: SummarizerApiComponent,
+  },
+  {
+    path: "summarizer-batch-api",
+    component: SummarizerBatchApiComponent,
   },
   {
     path: "writer-api",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -20,6 +20,7 @@ import {ToastStore} from './stores/toast.store';
 import {ToastComponent} from './components/toast/toast.component';
 import {RewriterApiComponent} from './pages/built-in-ai-apis/rewriter-api/rewriter-api.component';
 import {SummarizerApiComponent} from './pages/built-in-ai-apis/summarizer-api/summarizer-api.component';
+import {SummarizerBatchApiComponent} from './pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component';
 import {PromptApiComponent} from './pages/built-in-ai-apis/prompt-api/prompt-api.component';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import {PromptComponent} from './components/prompt/prompt.component';
@@ -100,6 +101,7 @@ import { PerformanceTestExecutionPage } from './pages/performance/performance-te
     ProofreaderApiComponent,
     RewriterApiComponent,
     SummarizerApiComponent,
+    SummarizerBatchApiComponent,
     TranslatorApiComponent,
     WriterApiComponent,
 

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -34,6 +34,11 @@
               <i class="bi bi-text-paragraph"></i>
               <span>Summarizer API</span></a>
           </li>
+          <li class="navigation-item"> <!-- [class.active] needs RouteEnum update -->
+            <a class="btn" routerLink="/summarizer-batch-api">
+              <i class="bi bi-collection"></i>
+              <span>Summarizer Batch API</span></a>
+          </li>
           <li class="navigation-item" [class.active]="this.currentRoute === RouteEnum.WriterApi">
             <a class="btn" routerLink="/writer-api">
               <i class="bi bi-pencil-square"></i>

--- a/src/app/pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component.html
+++ b/src/app/pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component.html
@@ -1,0 +1,225 @@
+<div class="container-fluid" xmlns="http://www.w3.org/1999/html">
+
+  <app-page-title [title]="'Summarizer Batch API'" [icon]="'bi-collection'">
+    <a class="btn btn-light"
+       href="https://github.com/webmachinelearning/writing-assistance-apis?tab=readme-ov-file#summarizer-api"
+       target="_blank"><i
+      class="bi bi-file-text"></i> <span class="ms-2">Explainer</span></a>
+    <a class="btn btn-light"
+       href="https://github.com/webmachinelearning/writing-assistance-apis/blob/main/index.bs#L124" target="_blank"><i
+      class="bi bi-body-text"></i> <span class="ms-2">Specifications</span></a>
+  </app-page-title>
+
+  <div class="row mb-3">
+    <div class="col-12">
+
+      <app-page-accordion
+        [requirementsStatus]="this.apiFlag.status"
+        (checkRequirementsEvent)="checkRequirements()"
+        [requirements]="[this.getRequirement()]"
+      >
+        <div debugInformation>
+          No debug information available.
+        </div>
+      </app-page-accordion>
+    </div>
+  </div>
+
+  <h2 class="display-6 mt-5"><i class="bi bi-play"></i> Playground</h2>
+  <hr>
+
+  <!-- Results Table -->
+  @if (results && results.length > 0 && (status === TaskStatus.Completed || status === TaskStatus.Error)) {
+    <h3 class="mt-4">Batch Results:</h3>
+    <div class="table-responsive">
+      <table class="table table-striped table-hover">
+        <thead>
+        <tr>
+          <th scope="col" style="width: 50%;">Input Text</th>
+          <th scope="col" style="width: 50%;">Summary</th>
+        </tr>
+        </thead>
+        <tbody>
+        @for (item of results; track item.input) {
+          <tr>
+            <td>
+              <pre class="preserve-whitespace">{{ item.input }}</pre>
+            </td>
+            <td>
+              <pre class="preserve-whitespace">{{ item.summary }}</pre>
+            </td>
+          </tr>
+        } @empty {
+          <tr>
+            <td colspan="2">No results to display.</td>
+          </tr>
+        }
+        </tbody>
+      </table>
+    </div>
+    <hr> <!-- Separator before the detailed app-output -->
+  }
+
+  <!-- Detailed Output/Progress -->
+  <app-output
+    [status]="this.status"
+    [error]="this.error"
+    [downloadProgress]="this.loaded"
+    [outputCollapsed]="outputCollapsed"
+    [statisticsCollapsed]="statisticsCollapsed"
+    [output]="this.output"
+    (abortExecution)="abortTriggered()"
+    (abortExecutionFromCreate)="abortFromCreateTriggered()"
+  >
+  </app-output>
+
+  <div class="row mt-5">
+    <div class="col-12 col-md-6">
+      <h3 class="mt-3">Inputs (one text per line for batch):</h3>
+      <textarea class="form-control" rows="8" [formControl]="inputFormControl" placeholder="Enter first text to summarize here...\nEnter second text to summarize here...\n...and so on."></textarea>
+
+      <h3 class="mt-3">Context (shared for all inputs in the batch):</h3>
+      <textarea class="form-control" rows="3" [formControl]="contextFormControl"></textarea>
+
+    </div>
+    <div class="col-12 col-md-6">
+      <h4 class="mt-4">Options (applied to all inputs in the batch)</h4>
+
+      <div class="row">
+        <div class="col-4">
+          <div class="mb-3">
+            <label for="summarizer-batch-tone" class="form-label">Tone</label>
+            <app-search-select-dropdown id="summarizer-batch-tone"
+                                        [options]="SummarizerTypeEnum | enumToSearchSelectDropdownOptions"
+                                        [control]="typeFormControl"
+                                        [name]="'summarizerType'"></app-search-select-dropdown>
+          </div>
+        </div>
+        <div class="col-4">
+          <div class="mb-3">
+            <label for="summarizer-batch-format" class="form-label">Format</label>
+            <app-search-select-dropdown id="summarizer-batch-format"
+                                        [options]="SummarizerFormatEnum | enumToSearchSelectDropdownOptions"
+                                        [control]="formatFormControl"
+                                        [name]="'summarizerFormat'"></app-search-select-dropdown>
+          </div>
+        </div>
+        <div class="col-4">
+          <div class="mb-3">
+            <label for="summarizer-batch-length" class="form-label">Length</label>
+            <app-search-select-dropdown id="summarizer-batch-length"
+                                        [options]="SummarizerLengthEnum | enumToSearchSelectDropdownOptions"
+                                        [control]="lengthFormControl"
+                                        [name]="'summarizerLength'"></app-search-select-dropdown>
+          </div>
+        </div>
+
+        <div class="col-6">
+          <div class="mb-3">
+            <label for="summarizer-batch-expected-input-languages" class="form-label">Expected Input Languages</label>
+            <app-search-select-multiple-dropdown id="summarizer-batch-expected-input-languages"
+                                                 [options]="LocaleEnum | enumToSearchSelectDropdownOptions"
+                                                 [control]="expectedInputLanguagesFormControl"
+                                                 [name]="'expectedInputLanguages'"></app-search-select-multiple-dropdown>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="mb-3">
+            <label for="summarizer-batch-expected-context-languages" class="form-label">Expected Context Languages</label>
+            <app-search-select-multiple-dropdown id="summarizer-batch-expected-context-languages"
+                                                 [options]="LocaleEnum | enumToSearchSelectDropdownOptions"
+                                                 [control]="expectedContextLanguagesFormControl"
+                                                 [name]="'expectedContextLanguages'"></app-search-select-multiple-dropdown>
+          </div>
+        </div>
+        <div class="col-6">
+          <div class="mb-3">
+            <label for="summarizer-batch-output-language" class="form-label">Output Language</label>
+            <app-search-select-dropdown id="summarizer-batch-output-language"
+                                        [options]="LocaleEnum | enumToSearchSelectDropdownOptions"
+                                        [control]="outputLanguageFormControl"
+                                        [name]="'outputLanguage'"></app-search-select-dropdown>
+          </div>
+
+        </div>
+        <div class="col-12">
+          <div class="mb-3">
+            <label for="summarizer-batch-context" class="form-label">Shared Context</label>
+            <textarea class="form-control" id="summarizer-batch-context" rows="3"
+                      [formControl]="sharedContextFormControl"></textarea>
+          </div>
+
+        </div>
+      </div>
+    </div>
+    <div class="d-grid mt-3">
+      <button class="btn btn-primary btn-lg" (click)="summarize()">Summarize Batch</button>
+    </div>
+  </div>
+
+  <h2 class="display-6 mt-5"><i class="bi bi-code-square"></i> Runnable code examples</h2>
+  <hr>
+
+  <div class="row">
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header">
+          <h4>Availability</h4>
+        </div>
+        <div class="card-body">
+          <h5>Code</h5>
+          <code-editor [code]="checkAvailabilityCode" [readonly]="true" [height]="'100px'"></code-editor>
+
+          <h5 class="mt-3">Result</h5>
+          <span class="code"
+                [class.code-warning]="availabilityStatus === AvailabilityStatusEnum.AfterDownload || availabilityStatus === AvailabilityStatusEnum.Downloadable"
+                [class.code-danger]="availabilityStatus === AvailabilityStatusEnum.No || availabilityStatus === AvailabilityStatusEnum.Unavailable"
+                [class.code-success]="availabilityStatus === AvailabilityStatusEnum.Readily || availabilityStatus === AvailabilityStatusEnum.Available"
+                [class.code-dark]="availabilityStatus === AvailabilityStatusEnum.Unknown"
+          >{{ availabilityStatus }}</span>
+
+          @if (availabilityError) {
+            <div class="alert alert-danger m-0 mt-2 mb-2">{{ availabilityError }}</div>
+          }
+
+          <div class="row mt-5">
+            <div class="col-12 d-grid">
+              <button class="btn btn-outline-primary d-block" (click)="checkAvailability()">Check availability</button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header d-flex">
+          <h4 class="flex-grow-1 m-0">Execute</h4>
+
+          <div class="form-check form-switch m-0 p-0">
+            <input class="form-check-input" type="checkbox" role="switch" id="flexSwitchCheckDefaultBatch"
+                   [formControl]="useStreamingFormControl">
+            <label class="form-check-label" for="flexSwitchCheckDefaultBatch">Streaming</label>
+          </div>
+        </div>
+        <div class="card-body">
+          <h5>Code (Example for first input in batch)</h5>
+          <code-editor [code]="summarizeCode" [readonly]="true" [height]="'250px'"></code-editor>
+
+          <div class="mt-3 mb-3 d-flex">
+          </div>
+          @if (status === TaskStatus.Error) {
+            <div class="alert alert-danger m-0 mb-2">{{ outputStatusMessage }}</div>
+          }
+
+          <div class="row mt-2">
+            <div class="col-12 d-grid">
+              <button class="btn btn-primary d-block" (click)="summarize()">Summarize Batch</button>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component.scss
+++ b/src/app/pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component.scss
@@ -1,0 +1,4 @@
+// SCSS for SummarizerBatchApiComponent
+// Initially, no specific styles are needed beyond what's inherited
+// or defined in shared component styles.
+// Add component-specific styles here if they arise.

--- a/src/app/pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component.ts
+++ b/src/app/pages/built-in-ai-apis/summarizer-batch-api/summarizer-batch-api.component.ts
@@ -1,0 +1,371 @@
+import {Component, EventEmitter, Inject, Input, OnInit, Output, PLATFORM_ID} from '@angular/core';
+import {TaskStatus} from '../../../enums/task-status.enum';
+import {RequirementStatus} from '../../../enums/requirement-status.enum';
+import {DOCUMENT, isPlatformBrowser} from '@angular/common';
+import {FormControl} from '@angular/forms';
+import {
+  BaseWritingAssistanceApiComponent
+} from '../../../components/base-writing-assistance-api/base-writing-assistance-api.component';
+import {AvailabilityStatusEnum} from '../../../enums/availability-status.enum';
+import {SummarizerTypeEnum} from '../../../enums/summarizer-type.enum';
+import {SummarizerFormatEnum} from '../../../enums/summarizer-format.enum';
+import {SummarizerLengthEnum} from '../../../enums/summarizer-length.enum';
+import {ActivatedRoute, Router} from '@angular/router';
+import {RequirementInterface} from '../../../interfaces/requirement.interface';
+import {Title} from '@angular/platform-browser';
+import {ExecutionPerformanceManager} from '../../../managers/execution-performance.manager';
+import {BuiltInAiApiEnum} from '../../../enums/built-in-ai-api.enum';
+
+
+@Component({
+  selector: 'app-summarizer-batch',
+  templateUrl: './summarizer-batch-api.component.html',
+  standalone: false,
+  styleUrl: './summarizer-batch-api.component.scss'
+})
+export class SummarizerBatchApiComponent extends BaseWritingAssistanceApiComponent implements OnInit {
+
+  // <editor-fold desc="Type">
+  private _type: SummarizerTypeEnum | null = SummarizerTypeEnum.Headline;
+  public typeFormControl: FormControl<SummarizerTypeEnum | null> = new FormControl<SummarizerTypeEnum | null>(SummarizerTypeEnum.Headline);
+
+  get type(): SummarizerTypeEnum | null {
+    return this._type;
+  }
+
+  @Input()
+  set type(value: SummarizerTypeEnum | null) {
+   this.setType(value);
+  }
+
+  setType(value: SummarizerTypeEnum | null, options?: {emitFormControlEvent?: boolean, emitChangeEvent?: boolean}) {
+    this._type = value;
+    this.typeFormControl.setValue(value, {emitEvent: options?.emitFormControlEvent ?? true});
+    if(options?.emitChangeEvent ?? true) {
+      this.typeChange.emit(value);
+    }
+
+    this.router.navigate(['.'], { relativeTo: this.route, queryParams: { summarizerType: value}, queryParamsHandling: 'merge' });
+  }
+
+  @Output()
+  typeChange = new EventEmitter<SummarizerTypeEnum | null>();
+  // </editor-fold>
+
+  // <editor-fold desc="Format">
+  private _format: SummarizerFormatEnum | null = SummarizerFormatEnum.PlainText;
+  public formatFormControl: FormControl<SummarizerFormatEnum | null> = new FormControl<SummarizerFormatEnum | null>(SummarizerFormatEnum.PlainText);
+
+  get format(): SummarizerFormatEnum | null {
+    return this._format;
+  }
+
+  @Input()
+  set format(value: SummarizerFormatEnum | null) {
+    this.setFormat(value);
+  }
+
+  setFormat(value: SummarizerFormatEnum | null, options?: {emitFormControlEvent?: boolean, emitChangeEvent?: boolean}) {
+    this._format = value;
+    this.formatFormControl.setValue(value, {emitEvent: options?.emitFormControlEvent ?? true});
+    if(options?.emitChangeEvent ?? true) {
+      this.formatChange.emit(value);
+    }
+
+    this.router.navigate(['.'], { relativeTo: this.route, queryParams: { summarizerFormat: value}, queryParamsHandling: 'merge' });
+  }
+
+  @Output()
+  formatChange = new EventEmitter<SummarizerFormatEnum | null>();
+  // </editor-fold>
+
+  // <editor-fold desc="Length">
+  private _length: SummarizerLengthEnum | null = SummarizerLengthEnum.Medium;
+  public lengthFormControl: FormControl<SummarizerLengthEnum | null> = new FormControl<SummarizerLengthEnum | null>(SummarizerLengthEnum.Medium);
+
+  get length(): SummarizerLengthEnum | null {
+    return this._length;
+  }
+
+  @Input()
+  set length(value: SummarizerLengthEnum | null) {
+    this.setLength(value);
+  }
+
+  setLength(value: SummarizerLengthEnum | null, options?: {emitFormControlEvent?: boolean, emitChangeEvent?: boolean}) {
+    this._length = value;
+    this.lengthFormControl.setValue(value, {emitEvent: options?.emitFormControlEvent ?? true});
+    if(options?.emitChangeEvent ?? true) {
+      this.lengthChange.emit(value);
+    }
+
+    this.router.navigate(['.'], { relativeTo: this.route, queryParams: { summarizerLength: value}, queryParamsHandling: 'merge' });
+  }
+
+  @Output()
+  lengthChange = new EventEmitter<SummarizerLengthEnum | null>();
+  // </editor-fold>
+
+  // Batch specific properties
+  public results: Array<{input: string, summary: string}> = []; // To store pairs of input and summary
+  public override inputFormControl = new FormControl<string>(''); // Keep existing input form control for now, might change based on UX for batch
+
+  get checkAvailabilityCode() {
+    return `Summarizer.availability({
+  type: '${this.typeFormControl.value}',
+  format: '${this.formatFormControl.value}',
+  length: '${this.lengthFormControl.value}',
+  expectedInputLanguages: ${JSON.stringify(this.expectedInputLanguagesFormControl.value)},
+  expectedContextLanguages: ${JSON.stringify(this.expectedContextLanguagesFormControl.value)},
+  outputLanguage: '${this.outputLanguageFormControl.value}',
+})`
+  }
+
+  // TODO: Adapt summarizeCode for batch processing if needed for display, or remove if not applicable.
+  // For now, it will reflect a single item summarization.
+  get summarizeCode() {
+    const inputs = this.inputFormControl.value?.split('\n').filter(input => input.trim() !== '') || ['']; // Simple split by newline for batch
+    const firstInput = inputs[0]; // Example: show code for the first input
+
+    if(this.useStreamingFormControl.value) {
+      return `const abortController = new AbortController();
+
+const summarizer = await Summarizer.create({
+  type: '${this.typeFormControl.value}',
+  format: '${this.formatFormControl.value}',
+  length: '${this.lengthFormControl.value}',
+  sharedContext: '${this.sharedContext}',
+  expectedInputLanguages: ${JSON.stringify(this.expectedInputLanguagesFormControl.value)},
+  expectedContextLanguages: ${JSON.stringify(this.expectedContextLanguagesFormControl.value)},
+  outputLanguage: '${this.outputLanguageFormControl.value}',
+  monitor(m: any)  {
+    m.addEventListener("downloadprogress", (e: any) => {
+      console.log(\`Downloaded \${e.loaded * 100}%\`);
+    });
+  },
+  signal: abortController.signal,
+})
+
+// Example for one input; loop for batch
+const stream: ReadableStream = summarizer.summarizeStreaming('${firstInput}', {context: '${this.contextFormControl.value}'});
+
+let output = "";
+for await (const chunk of stream) {
+  // Do something with each 'chunk'
+  output += chunk;
+}
+
+// See the complete response here
+console.log(output);`;
+    } else {
+      return `const abortController = new AbortController();
+
+const summarizer = await Summarizer.create({
+  type: '${this.typeFormControl.value}',
+  format: '${this.formatFormControl.value}',
+  length: '${this.lengthFormControl.value}',
+  sharedContext: '${this.sharedContext}',
+  expectedInputLanguages: ${JSON.stringify(this.expectedInputLanguagesFormControl.value)},
+  expectedContextLanguages: ${JSON.stringify(this.expectedContextLanguagesFormControl.value)},
+  outputLanguage: '${this.outputLanguageFormControl.value}',
+  monitor(m: any)  {
+    m.addEventListener("downloadprogress", (e: any) => {
+      console.log(\`Downloaded \${e.loaded * 100}%\`);
+    });
+  },
+  signal: abortController.signal,
+})
+
+// Example for one input; loop for batch
+const output = await summarizer.summarize('${firstInput}', {context: '${this.contextFormControl.value}'})
+
+// See the complete response here
+console.log(output);`;
+    }
+  }
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: Object,
+    @Inject(DOCUMENT) document: Document,
+    router: Router,
+    route: ActivatedRoute,
+    title: Title,
+    private readonly executionPerformanceManager: ExecutionPerformanceManager,
+  ) {
+    super(document, router, route, title);
+  }
+
+
+  override ngOnInit() {
+    super.ngOnInit();
+
+    this.checkRequirements()
+    this.executionPerformanceManager.reset();
+
+    this.subscriptions.push(this.route.queryParams.subscribe((params) => {
+      if (params['summarizerType']) {
+        this.typeFormControl.setValue(params['summarizerType']);
+      }
+
+      if (params['summarizerFormat']) {
+        this.formatFormControl.setValue(params['summarizerFormat']);
+      }
+
+      if (params['summarizerLength']) {
+        this.lengthFormControl.setValue(params['summarizerLength']);
+      }
+    }));
+
+
+    // Register form changes events
+    this.subscriptions.push(this.typeFormControl.valueChanges.subscribe((value) => {
+      this.setType(value, {emitChangeEvent: true, emitFormControlEvent: false});
+    }));
+    this.subscriptions.push(this.formatFormControl.valueChanges.subscribe((value) => {
+      this.setFormat(value, {emitChangeEvent: true, emitFormControlEvent: false});
+    }));
+    this.subscriptions.push(this.lengthFormControl.valueChanges.subscribe((value) => {
+      this.setLength(value);
+    }));
+  }
+
+  getRequirement(): RequirementInterface {
+    return {
+      ...this.apiFlag,
+      contentHtml: `Activate <span class="code">chrome://flags/#summarization-api-for-gemini-nano</span>`,
+    }
+  }
+
+  checkRequirements() {
+    if (isPlatformBrowser(this.platformId) && (!this.window || !("Summarizer" in this.window))) {
+      this.apiFlag.status = RequirementStatus.Fail;
+      this.apiFlag.message = "'Summarizer' is not defined. Activate the flag.";
+    } else if(isPlatformBrowser(this.platformId)) {
+      this.apiFlag.status = RequirementStatus.Pass;
+      this.apiFlag.message = "Passed";
+    }
+  }
+
+  async checkAvailability() {
+    try {
+      // @ts-ignore
+      this.availabilityStatus = await Summarizer.availability({
+        type: this.typeFormControl.value,
+        format: this.formatFormControl.value,
+        length: this.lengthFormControl.value,
+        expectedInputLanguages: this.expectedInputLanguagesFormControl.value,
+        expectedContextLanguages: this.expectedContextLanguagesFormControl.value,
+        outputLanguage: this.outputLanguageFormControl.value
+      })
+    } catch (e: any) {
+      this.availabilityStatus = AvailabilityStatusEnum.Unavailable
+      this.errorChange.emit(e);
+      this.availabilityError = e;
+    }
+  }
+
+  async summarize() {
+    this.status = TaskStatus.Executing;
+    this.outputCollapsed = false;
+    this.outputStatusMessage = "Preparing and downloading model...";
+    this.results = []; // Reset results for batch
+    this.error = undefined;
+    // this.outputChunksChange.emit(this.outputChunks); // TODO: How to handle chunks for batch?
+    this.output = ""; // Clear single output, using results array now
+    this.outputStatusMessage = "Running query...";
+    this.loaded = 0;
+    this.executionPerformanceManager.start(BuiltInAiApiEnum.Summarizer) // TODO: Change to SummarizerBatch if new enum value
+
+    const inputs = this.inputFormControl.value?.split('\n').filter(input => input.trim() !== '') || [];
+    if (inputs.length === 0) {
+      this.status = TaskStatus.Error;
+      this.outputStatusMessage = "Error: No inputs provided for summarization.";
+      this.error = new Error("No inputs provided.");
+      this.errorChange.emit(this.error);
+      return;
+    }
+
+    try {
+      const self = this;
+      this.abortControllerFromCreate  = new AbortController();
+      this.abortController = new AbortController();
+
+      this.executionPerformanceManager.sessionCreationStarted({
+        type: this.typeFormControl.value,
+        format: this.formatFormControl.value,
+        length: this.lengthFormControl.value,
+        sharedContext: this.sharedContext,
+        expectedInputLanguages: this.expectedInputLanguagesFormControl.value,
+        expectedContextLanguages: this.expectedContextLanguagesFormControl.value,
+        outputLanguage: this.outputLanguageFormControl.value
+      });
+
+      // @ts-expect-error
+      const summarizer = await Summarizer.create({
+        type: this.typeFormControl.value,
+        format: this.formatFormControl.value,
+        length: this.lengthFormControl.value,
+        sharedContext: this.sharedContext,
+        expectedInputLanguages: this.expectedInputLanguagesFormControl.value,
+        expectedContextLanguages: this.expectedContextLanguagesFormControl.value,
+        outputLanguage: this.outputLanguageFormControl.value,
+        monitor(m: any)  {
+          m.addEventListener("downloadprogress", (e: any) => {
+            console.log(`Downloaded ${e.loaded * 100}%`);
+            self.loaded = e.loaded;
+            self.executionPerformanceManager.downloadUpdated(e.loaded)
+          });
+        },
+        signal: this.abortControllerFromCreate.signal,
+      });
+      this.executionPerformanceManager.sessionCreationCompleted()
+
+      for (const singleInput of inputs) {
+        if (this.abortController.signal.aborted || this.abortControllerFromCreate.signal.aborted) {
+          this.outputStatusMessage = "Execution aborted.";
+          break;
+        }
+
+        this.executionPerformanceManager.inferenceStarted({streaming: this.useStreamingFormControl.value, input: singleInput, context: this.contextFormControl.value});
+        let currentOutput = "";
+        if(this.useStreamingFormControl.value) {
+          // TODO: Streaming for batch needs careful consideration on how to display.
+          // For now, concatenate results.
+          const stream: ReadableStream = summarizer.summarizeStreaming(singleInput, {context: this.contextFormControl.value, signal: this.abortController.signal});
+          for await (const chunk of stream) {
+            this.executionPerformanceManager.tokenReceived();
+            currentOutput += chunk;
+          }
+        } else {
+          currentOutput = await summarizer.summarize(singleInput, {context: this.contextFormControl.value, signal: this.abortController.signal});
+          this.executionPerformanceManager.tokenReceived();
+        }
+        this.results.push({input: singleInput, summary: currentOutput});
+        // Update combined output for app-output component (optional, if table is primary)
+        this.output = this.results.map(r => `Input:\n${r.input}\n\nSummary:\n${r.summary}`).join('\n\n---\n\n');
+        this.executionPerformanceManager.inferenceCompleted();
+      }
+
+      if (this.abortController.signal.aborted || this.abortControllerFromCreate.signal.aborted) {
+          this.status = TaskStatus.Error;
+          this.outputStatusMessage = "Execution aborted by user.";
+      } else {
+          this.status = TaskStatus.Completed;
+      }
+
+    } catch (e: any) {
+      this.status = TaskStatus.Error;
+      this.outputStatusMessage = `Error: ${e}`;
+      this.errorChange.emit(e);
+      this.error = e;
+      // Ensure session creation completed is called in case of error during creation
+      this.executionPerformanceManager.sessionCreationCompleted();
+      this.executionPerformanceManager.inferenceCompleted(); // Mark inference as completed on error
+    }
+    // Removed finally block as inferenceCompleted is called within loop/error handling
+  }
+
+  SummarizerTypeEnum = SummarizerTypeEnum;
+  SummarizerFormatEnum = SummarizerFormatEnum;
+  SummarizerLengthEnum = SummarizerLengthEnum;
+}


### PR DESCRIPTION
This commit introduces a new page, `SummarizerBatchPageComponent`, which allows you to summarize multiple text inputs in a batch.

The new page includes:
- A form at the top with options to configure the Summarizer (Type, Format, Length, Languages, Context), similar to the existing SummarizerPage. These options are applied to all inputs in the batch.
- A textarea for you to input multiple texts, with each line treated as a separate input.
- A results table displaying each input text alongside its generated summary.
- The page is accessible via the route `/summarizer-batch-api` and has a corresponding link in the sidebar navigation.

The component `SummarizerBatchApiComponent` is marked as `standalone: false` and has been added to the `AppModule` declarations.