### PR TITLE
feat: Implement multi-line paste for summarizer batch input

### DIFF
--- a/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
+++ b/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
@@ -14,7 +14,7 @@
       <tbody formArrayName="inputs">
         <tr *ngFor="let control of inputControls; let i = index">
           <td>
-            <textarea class="form-control" rows="3" [formControlName]="i"></textarea>
+            <textarea class="form-control" rows="3" [formControlName]="i" (paste)="onPaste($event, i)"></textarea>
           </td>
           <td>
             <textarea class="form-control" rows="3" disabled placeholder="Output will appear here"></textarea>

--- a/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.ts
+++ b/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.ts
@@ -47,4 +47,27 @@ export class SummarizerBatchPageComponent extends BaseComponent implements OnIni
     const inputs = this.batchForm.get('inputs') as FormArray;
     inputs.push(this.fb.control(''));
   }
+
+  public onPaste(event: ClipboardEvent, rowIndex: number): void {
+    event.preventDefault();
+    const pastedText = event.clipboardData?.getData('text');
+    if (!pastedText) {
+      return;
+    }
+
+    const lines = pastedText.split('\n').map(line => line.trim());
+    const inputs = this.batchForm.get('inputs') as FormArray;
+
+    if (lines.length > 0) {
+      // Set the first line to the current input
+      inputs.at(rowIndex).setValue(lines[0]);
+
+      // For subsequent lines, insert new rows
+      for (let i = 1; i < lines.length; i++) {
+        const newFormControl = this.fb.control(lines[i]);
+        // Insert after the current rowIndex + number of lines already added
+        inputs.insert(rowIndex + i, newFormControl);
+      }
+    }
+  }
 }


### PR DESCRIPTION
This commit introduces functionality to handle pasting multiple lines of text into the input fields on the summarizer batch page.

When you paste content (e.g., from a spreadsheet column) into a textarea:
- The first line of the pasted content populates the target textarea.
- Each subsequent line of the pasted content automatically creates a new input row below the target row and populates it with the respective line's content.

This enhancement improves your experience by allowing for quicker entry of multiple inputs.