### PR TITLE
feat: Add Status and Actions columns to Summarizer Batch Page

### DIFF
--- a/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
+++ b/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
@@ -7,8 +7,10 @@
     <table class="table table-hover">
       <thead>
         <tr>
-          <th scope="col" style="width: 50%;">Input</th>
-          <th scope="col" style="width: 50%;">Output</th>
+          <th scope="col" style="width: 25%;">Input</th>
+          <th scope="col" style="width: 25%;">Output</th>
+          <th scope="col" style="width: 25%;">Status</th>
+          <th scope="col" style="width: 25%;">Actions</th>
         </tr>
       </thead>
       <tbody formArrayName="inputs">
@@ -18,6 +20,10 @@
           </td>
           <td>
             <textarea class="form-control" rows="3" disabled placeholder="Output will appear here"></textarea>
+          </td>
+          <td></td>
+          <td>
+            <button class="btn btn-sm btn-danger" (click)="deleteRow(i)">Delete Row</button>
           </td>
         </tr>
       </tbody>

--- a/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.ts
+++ b/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.ts
@@ -48,6 +48,11 @@ export class SummarizerBatchPageComponent extends BaseComponent implements OnIni
     inputs.push(this.fb.control(''));
   }
 
+  deleteRow(index: number): void {
+    const inputs = this.batchForm.get('inputs') as FormArray;
+    inputs.removeAt(index);
+  }
+
   public onPaste(event: ClipboardEvent, rowIndex: number): void {
     event.preventDefault();
     const pastedText = event.clipboardData?.getData('text');


### PR DESCRIPTION
This commit introduces two new columns, "Status" and "Actions", to the Summarizer Batch Page.

- The "Status" column is initially empty.
- The "Actions" column contains a "Delete Row" button for each row, allowing you to remove rows dynamically.
- Column widths have been adjusted to 25% for each of the four columns (Input, Output, Status, Actions).
- The `deleteRow(index)` method has been implemented in the component to handle row deletion.