### PR TITLE
Refactor: Update Summarizer Batch Page UI and Form Logic

### DIFF
--- a/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
+++ b/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
@@ -1,9 +1,6 @@
 <app-page-title [title]="'Summarizer Batch'" [icon]="'bi-journal-text'"></app-page-title>
 <div class="container mt-4">
   <form [formGroup]="batchForm">
-    <div class="mb-3">
-      <button type="button" class="btn btn-primary" (click)="addRow()">Add Row</button>
-    </div>
     <table class="table table-hover">
       <thead>
         <tr>
@@ -14,19 +11,29 @@
         </tr>
       </thead>
       <tbody formArrayName="inputs">
-        <tr *ngFor="let control of inputControls; let i = index">
+        <tr *ngFor="let row of rowControls; let i = index">
           <td>
-            <textarea class="form-control" rows="3" [formControlName]="i" (paste)="onPaste($event, i)"></textarea>
+            <textarea class="form-control" rows="3" [formControl]="row.get('text')" (paste)="onPaste($event, i)"></textarea>
           </td>
           <td>
             <textarea class="form-control" rows="3" disabled placeholder="Output will appear here"></textarea>
           </td>
-          <td></td>
+          <td>
+            <span class="badge"
+                  [class.text-bg-secondary]="rowControls[i].get('status').value === TaskStatus.Idle"
+                  [class.text-bg-primary]="rowControls[i].get('status').value === TaskStatus.Executing"
+                  [class.text-bg-success]="rowControls[i].get('status').value === TaskStatus.Completed"
+                  [class.text-bg-danger]="rowControls[i].get('status').value === TaskStatus.Error"
+            >{{ rowControls[i].get('status').value }}</span>
+          </td>
           <td>
             <button class="btn btn-sm btn-danger" (click)="deleteRow(i)">Delete Row</button>
           </td>
         </tr>
       </tbody>
     </table>
+    <div class="mb-3">
+      <button type="button" class="btn btn-primary" (click)="addRow()">Add Row</button>
+    </div>
   </form>
 </div>


### PR DESCRIPTION
This commit addresses two main UI/UX improvements for the Summarizer Batch Page:

1.  **Moved 'Add Row' Button:** The 'Add Row' button has been relocated from above the table to below it, improving the workflow for adding multiple entries.

2.  **Task Status Display:**
    *   Integrated `TaskStatus` enum for each row in the batch table.
    *   The underlying form structure (`batchForm`) now uses a `FormArray` of `FormGroup`s, where each group holds controls for the input text and its corresponding status.
    *   A new 'Status' column in the table now displays the task status for each row using a styled badge. The badge's appearance (color) changes based on the `TaskStatus` (Idle, Executing, Completed, Error) via class bindings.
    *   Methods `addRow`, `addInitialInput`, and `onPaste` were updated to support the new form structure and initialize row status to `TaskStatus.Idle` by default.

These changes enhance the usability of the batch summarizer by providing clearer visual feedback on task states and a more intuitive layout for adding new input rows.