### PR TITLE
Refactor: Update batchForm structure in SummarizerBatchPage

### DIFF
--- a/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
+++ b/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.html
@@ -93,22 +93,21 @@
             <th scope="col" style="width: 25%;">Actions</th>
           </tr>
           </thead>
-          <tbody formArrayName="inputs">
-          <tr *ngFor="let row of rowControls; let i = index">
+          <tbody>
+          <tr *ngFor="let row of rowControls; let i = index" [formGroupName]="i">
             <td>
-              <textarea class="form-control" rows="3" [formControl]="getTextControl(i)" (paste)="onPaste($event, i)"></textarea>
-            </td>
-
-            <td>
-            <span class="badge"
-                  [class.text-bg-secondary]="getStatusValue(i) === StoredTaskStatus.Idle"
-                  [class.text-bg-primary]="getStatusValue(i) === StoredTaskStatus.Executing"
-                  [class.text-bg-success]="getStatusValue(i) === StoredTaskStatus.Completed"
-                  [class.text-bg-danger]="getStatusValue(i) === StoredTaskStatus.Error"
-            >{{ getStatusValue(i) }}</span>
+              <textarea class="form-control" rows="3" formControlName="input" (paste)="onPaste($event, i)"></textarea>
             </td>
             <td>
-              <textarea class="form-control" rows="3" disabled placeholder="Output will appear here"></textarea>
+              <textarea class="form-control" formControlName="output" disabled></textarea>
+            </td>
+            <td>
+              <span class="badge"
+                    [class.text-bg-secondary]="getStatusValue(i) === StoredTaskStatus.Idle"
+                    [class.text-bg-primary]="getStatusValue(i) === StoredTaskStatus.Executing"
+                    [class.text-bg-success]="getStatusValue(i) === StoredTaskStatus.Completed"
+                    [class.text-bg-danger]="getStatusValue(i) === StoredTaskStatus.Error"
+              >{{ getStatusValue(i) }}</span>
             </td>
             <td>
               <button class="btn btn-sm btn-danger" (click)="deleteRow(i)">Delete Row</button>


### PR DESCRIPTION
I've replaced the existing batchForm FormGroup with a FormArray of FormGroups to allow for more structured handling of input, status, and output fields for each batch item.

Key changes:
- Modified `batchForm` in `summarizer-batch-page.component.ts` to be a `FormArray<FormGroup<{ input: FormControl<string| null>, status: FormControl<TaskStatus | null>, output: FormControl<string | null> }>>`.
- Updated component logic (`addInitialInput`, `addRow`, `deleteRow`, `onPaste`, `getInputControl`, `getStatusValue`, and added `getOutputControl`) to work with the new FormArray structure.
- Updated `summarizer-batch-page.component.html` template to reflect the new form structure, including adding a disabled textarea for output and adjusting form control bindings.