### PR TITLE
Fix: Remove newlines from batch summarizer output before copying

### DIFF
--- a/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.ts
+++ b/src/app/pages/summarizer-batch-page/summarizer-batch-page.component.ts
@@ -229,7 +229,7 @@ export class SummarizerBatchPageComponent extends BaseWritingAssistanceApiCompon
   }
 
   copyOutputToClipboard(): void {
-    const outputText = this.form.controls.map(control => control.controls.output.value).join('\n');
+    const outputText = this.form.controls.map(control => control.controls.output.value?.replace(/\n/g, '')).join('\n');
     if (outputText) {
       navigator.clipboard.writeText(outputText).then(() => {
         console.log('Output copied to clipboard');


### PR DESCRIPTION
Modifies the `copyOutputToClipboard` method in `SummarizerBatchPageComponent`. Previously, newlines within individual summarized outputs were preserved when copied to the clipboard. This change ensures that all newline characters within each output field are removed before the collected outputs are joined by a single newline for clipboard copying. This addresses the issue of unwanted newlines in the copied text, making it cleaner for pasting elsewhere.