### PR TITLE
Style: Improve Select Box Dropdown

### DIFF
--- a/src/app/components/search-select-dropdown/search-select-dropdown.component.scss
+++ b/src/app/components/search-select-dropdown/search-select-dropdown.component.scss
@@ -11,6 +11,11 @@
   }
 }
 
+.dropdown-menu {
+  max-height: 350px;
+  overflow-y: auto;
+}
+
 .focus {
   color: $input-focus-color;
   background-color: $input-focus-bg !important;

--- a/src/app/components/search-select-multiple-dropdown/search-select-multiple-dropdown.component.scss
+++ b/src/app/components/search-select-multiple-dropdown/search-select-multiple-dropdown.component.scss
@@ -17,6 +17,11 @@ input {
   }
 }
 
+.dropdown-menu {
+  max-height: 350px;
+  overflow-y: auto;
+}
+
 .focus {
   color: $input-focus-color;
   background-color: $input-focus-bg !important;


### PR DESCRIPTION
This PR improves the select dropdown height and enhance better user experience.

This will prevents the dropdown from growing too tall and overflowing the viewport, providing a better user experience especially on smaller screens.

Before:

<img width="1919" height="966" alt="image" src="https://github.com/user-attachments/assets/ba48346f-92a9-46a9-b15f-121b400e6437" />



After: 

<img width="1920" height="964" alt="image" src="https://github.com/user-attachments/assets/d7058b29-bb79-453c-8dae-22425cfc8aad" />
