### PR TITLE
Add Semantic Embedder API playground and reference

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -21,6 +21,9 @@ import {RouteEnum} from './enums/route.enum';
 import {DownloadTesterPage} from './pages/download-tester/download-tester.page';
 import {ProofreaderApiComponent} from './pages/built-in-ai-apis/proofreader-api/proofreader-api.component';
 import {AutocompleteComponent} from './pages/built-in-ai-apis/autocomplete/autocomplete.component';
+import {
+  SemanticEmbedderApiComponent
+} from './pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component';
 import {PerformanceHistoryPage} from './pages/performance/performance-history/performance-history.page';
 import {PerformanceTestRunnerPage} from './pages/performance/performance-test-runner/performance-test-runner.page';
 import {PerformanceTestExecutionPage} from './pages/performance/performance-test-execution-page/performance-test-execution-page';
@@ -57,6 +60,10 @@ const layouts: Routes = [
   {
     path: "proofreader-api",
     component: ProofreaderApiComponent,
+  },
+  {
+    path: RouteEnum.SemanticEmbedderApi,
+    component: SemanticEmbedderApiComponent,
   },
   {
     path: "autocomplete",

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -53,6 +53,9 @@ import {EnumToMagienoDropdownItemsPipe} from './pipes/enum-to-magieno-dropdown-i
 import {DownloadTesterPage} from './pages/download-tester/download-tester.page';
 import {ProofreaderApiComponent} from './pages/built-in-ai-apis/proofreader-api/proofreader-api.component';
 import {AutocompleteComponent} from './pages/built-in-ai-apis/autocomplete/autocomplete.component';
+import {
+  SemanticEmbedderApiComponent
+} from './pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component';
 import {ExecutionPerformanceManager} from './managers/execution-performance.manager';
 import {InferencePerformanceManager} from '../performance-test/managers/inference-performance.manager';
 import {ExecutionPerformanceComponent} from './components/execution-performance/execution-performance.component';
@@ -112,6 +115,7 @@ import {AvailabilityCreatorPage} from './pages/availability-creator/availability
     PromptApiComponent,
     ProofreaderApiComponent,
     RewriterApiComponent,
+    SemanticEmbedderApiComponent,
     SummarizerApiComponent,
     TranslatorApiComponent,
     SummarizerBatchPageComponent,

--- a/src/app/components/sidebar/sidebar.component.html
+++ b/src/app/components/sidebar/sidebar.component.html
@@ -95,6 +95,14 @@
 
           </li>
 
+          <li class="navigation-item" [class.active]="this.currentRoute === RouteEnum.SemanticEmbedderApi">
+            <a class="btn" routerLink="/semantic-embedder-api">
+              <i class="bi bi-diagram-3"></i>
+              <span>Semantic Embedder API</span>
+              <span class="badge text-bg-warning">Experimental</span>
+            </a>
+          </li>
+
           <li class="navigation-item" [class.active]="this.currentRoute === RouteEnum.MultimodalPromptApi">
             <a class="btn" routerLink="/multimodal-prompt-api">
               <i class="bi bi-collection-play-fill"></i>

--- a/src/app/components/sidebar/sidebar.component.ts
+++ b/src/app/components/sidebar/sidebar.component.ts
@@ -54,6 +54,8 @@ export class SidebarComponent extends BaseComponent implements OnInit {
       this.currentRoute = RouteEnum.LanguageDetectorApi;
     } else if(url.endsWith('download-tester')) {
       this.currentRoute = RouteEnum.DownloadTester;
+    } else if(url.endsWith('semantic-embedder-api')) {
+      this.currentRoute = RouteEnum.SemanticEmbedderApi;
     }
     // @start-remove-in-chrome-dev
     else if(url.endsWith('transcription-audio-multimodal-prompt-api')) {

--- a/src/app/enums/built-in-ai-api.enum.ts
+++ b/src/app/enums/built-in-ai-api.enum.ts
@@ -3,6 +3,7 @@ export enum BuiltInAiApiEnum {
   Prompt = "PROMPT",
   Proofreader = "PROOFREADER",
   Rewriter = "REWRITER",
+  SemanticEmbedder = "SEMANTIC_EMBEDDER",
   Summarizer = "SUMMARIZER",
   Translator = "TRANSLATOR",
   Writer = "WRITER",

--- a/src/app/enums/route.enum.ts
+++ b/src/app/enums/route.enum.ts
@@ -6,6 +6,7 @@ export enum RouteEnum {
   WriterApi = 'writer-api',
   RewriterApi = 'rewriter-api',
   ProofreaderApi = 'proofreader-api',
+  SemanticEmbedderApi = 'semantic-embedder-api',
   Autocomplete = 'autocomplete',
   SummarizerApi = 'summarizer-api',
   PromptApi = 'prompt-api',

--- a/src/app/enums/semantic-embedder-task-type.enum.ts
+++ b/src/app/enums/semantic-embedder-task-type.enum.ts
@@ -1,0 +1,14 @@
+/**
+ * Optional hint passed to `SemanticEmbedder.embed()` to let the underlying model optimize the
+ * embedding for a specific downstream task.
+ *
+ * The explainer only names `retrieval` and `classification` explicitly and states that the hint is
+ * strictly optional: a browser is allowed to ignore it entirely if its model doesn't support task
+ * types.
+ *
+ * @see https://github.com/explainers-by-googlers/semantic-embedder-api#task-type-optimization-hints
+ */
+export enum SemanticEmbedderTaskTypeEnum {
+  Retrieval = 'retrieval',
+  Classification = 'classification',
+}

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedder-embedding.interface.ts
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedder-embedding.interface.ts
@@ -1,0 +1,18 @@
+/**
+ * A single embedding, corresponding 1:1 with one of the inputs passed to `embed()`.
+ */
+export interface EmbedderEmbeddingInterface {
+  /**
+   * The raw vector representation of the input.
+   */
+  values: Float32Array;
+
+  /**
+   * Per-embedding statistics. Marked as "future extensibility" in the explainer, so it may be
+   * absent depending on the implementation.
+   */
+  statistics?: {
+    tokenCount?: number;
+    truncated?: boolean;
+  };
+}

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedder-metadata.interface.ts
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedder-metadata.interface.ts
@@ -1,0 +1,16 @@
+/**
+ * Describes the mathematical vector space the returned embeddings belong to. Exposed on the
+ * `EmbedderResult` so developers can version their local vector databases and know which
+ * server-side models the vectors are compatible with.
+ */
+export interface EmbedderMetadataInterface {
+  /**
+   * Identifier of the embedding space / model that produced the vectors (e.g. `embeddinggemma-300m`).
+   */
+  embeddingSpace?: string;
+
+  /**
+   * Maximum number of tokens a single input can contain before it gets truncated.
+   */
+  maxInputTokens?: number;
+}

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedder-result.interface.ts
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedder-result.interface.ts
@@ -1,0 +1,16 @@
+import {EmbedderEmbeddingInterface} from './embedder-embedding.interface';
+import {EmbedderMetadataInterface} from './embedder-metadata.interface';
+
+/**
+ * The structured object returned by `SemanticEmbedder.embed()`. A dictionary is returned rather
+ * than a raw array so the API can be extended (statistics, truncation warnings, multi-modal
+ * metadata) without breaking early adopters.
+ */
+export interface EmbedderResultInterface {
+  /**
+   * Corresponds strictly 1:1 with the inputs provided to `embed()`.
+   */
+  embeddings: EmbedderEmbeddingInterface[];
+
+  metadata?: EmbedderMetadataInterface;
+}

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedding-row.interface.ts
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/interfaces/embedding-row.interface.ts
@@ -1,0 +1,23 @@
+/**
+ * View model used by the playground to render one row of the embeddings table.
+ */
+export interface EmbeddingRowInterface {
+  index: number;
+
+  input: string;
+
+  /**
+   * Number of dimensions of the returned vector.
+   */
+  dimensions: number;
+
+  tokenCount?: number;
+
+  truncated?: boolean;
+
+  /**
+   * The full vector, kept around so the similarity matrix can be computed and so the raw values
+   * can be copied out of the page.
+   */
+  values: number[];
+}

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.html
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.html
@@ -1,0 +1,369 @@
+<div class="container-fluid" xmlns="http://www.w3.org/1999/html">
+
+  <app-page-title [title]="'Semantic Embedder API'" [icon]="'bi-diagram-3'">
+    <a class="btn btn-light"
+       href="https://github.com/explainers-by-googlers/semantic-embedder-api"
+       target="_blank"><i class="bi bi-file-text"></i> <span class="ms-2">Explainer</span></a>
+    <a class="btn btn-light disabled"
+       href="https://github.com/explainers-by-googlers/semantic-embedder-api"
+       target="_blank"><i class="bi bi-body-text"></i> <span class="ms-2">Specifications</span></a>
+  </app-page-title>
+
+  <div class="row mb-3">
+    <div class="col-12">
+      <app-page-accordion
+        [requirementsStatus]="this.apiFlag.status"
+        (checkRequirementsEvent)="checkRequirements()"
+        [requirements]="getRequirements()"
+      >
+        <div debugInformation>
+          <p>The Semantic Embedder API is an <strong>early design sketch</strong> from the Chrome Built-in AI team and
+            has not been approved to ship in Chrome. The surface below follows the explainer and may change.</p>
+          <p class="mt-1">Embeddings are only comparable within the same embedding space: check
+            <span class="code">result.metadata.embeddingSpace</span> before comparing vectors you stored earlier.</p>
+        </div>
+      </app-page-accordion>
+    </div>
+  </div>
+
+  <h2 class="display-6 mt-5"><i class="bi bi-play"></i> Playground</h2>
+  <hr>
+
+  <app-output
+    [status]="this.embedStatus"
+    [error]="this.error"
+    [downloadProgress]="this.loaded"
+    [outputCollapsed]="outputCollapsed"
+    [statisticsCollapsed]="statisticsCollapsed"
+    [output]="this.output"
+    (abortExecution)="abortTriggered()"
+    (abortExecutionFromCreate)="abortFromCreateTriggered()"
+  >
+    @if (rows.length > 0) {
+      @if (metadata) {
+        <div class="mb-3">
+          @if (metadata.embeddingSpace) {
+            <span class="code me-2">embeddingSpace: {{ metadata.embeddingSpace }}</span>
+          }
+          @if (metadata.maxInputTokens) {
+            <span class="code">maxInputTokens: {{ metadata.maxInputTokens }}</span>
+          }
+        </div>
+      }
+
+      <h5>Embeddings</h5>
+      <div style="max-height: 400px; overflow: auto">
+        <table class="table table-responsive">
+          <thead>
+          <tr>
+            <th>#</th>
+            <th>Input</th>
+            <th>Dimensions</th>
+            <th>Tokens</th>
+            <th>Values (first {{ previewLength }})</th>
+          </tr>
+          </thead>
+          <tbody>
+            @for (row of rows; track row.index) {
+              <tr>
+                <td>{{ row.index }}</td>
+                <td>{{ row.input }}</td>
+                <td>{{ row.dimensions }}</td>
+                <td>
+                  {{ row.tokenCount ?? '—' }}
+                  @if (row.truncated) {
+                    <span class="badge text-bg-warning ms-1">truncated</span>
+                  }
+                </td>
+                <td><span class="code">{{ getPreview(row) }}</span></td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+
+      <h5 class="mt-4">Cosine similarity</h5>
+      <p class="text-muted"><small>Computed in JavaScript from the returned vectors: the API does not expose a built-in
+        comparison method.</small></p>
+      <div style="max-height: 400px; overflow: auto">
+        <table class="table table-responsive">
+          <thead>
+          <tr>
+            <th></th>
+            @for (row of rows; track row.index) {
+              <th>#{{ row.index }}</th>
+            }
+          </tr>
+          </thead>
+          <tbody>
+            @for (row of rows; track row.index) {
+              <tr>
+                <th>#{{ row.index }}</th>
+                @for (similarity of similarityMatrix[row.index]; track $index) {
+                  <td>{{ similarity | number: '1.4-4' }}</td>
+                }
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+    }
+  </app-output>
+
+  <div class="row mt-4">
+    <div class="col-12">
+      <label for="input" class="form-label">Inputs <small class="text-muted">(one passage per line — they are sent
+        as a single batch)</small></label>
+      <textarea id="input" class="form-control" rows="8"
+                placeholder="Enter one passage per line."
+                [formControl]="inputFormControl"></textarea>
+    </div>
+  </div>
+
+  <div class="row mt-3">
+    <div class="col-12 col-md-6">
+      <label for="task-type" class="form-label">Task type <small class="text-muted">(optional hint)</small></label>
+      <select id="task-type" class="form-select" [formControl]="taskTypeFormControl">
+        <option [ngValue]="null">None</option>
+        @for (taskType of SemanticEmbedderTaskTypeEnum | keyvalue; track taskType.key) {
+          <option [ngValue]="taskType.value">{{ taskType.value }}</option>
+        }
+      </select>
+      <div class="form-text">Browsers may safely ignore this hint if their model does not support task types.</div>
+    </div>
+  </div>
+
+  <div class="d-grid">
+    <button class="btn btn-primary btn-lg mt-4" (click)="embed()">Embed</button>
+  </div>
+
+  <h2 class="display-6 mt-5"><i class="bi bi-code-square"></i> Runnable code examples</h2>
+  <hr>
+
+  <div class="row mt-4">
+    <div class="col-12 col-xl-6">
+      <app-card [status]="availabilityTaskStatus">
+        <div header><h3 class="m-0">Availability</h3></div>
+        <div class="card-body">
+          <h5>Code</h5>
+          <code-editor [code]="availabilityCode" [readonly]="true" [height]="'100px'"></code-editor>
+
+          <h5 class="mt-3">Result</h5>
+          <span class="code"
+                [class.code-warning]="availabilityStatus === AvailabilityStatusEnum.Downloadable || availabilityStatus === AvailabilityStatusEnum.Downloading"
+                [class.code-danger]="availabilityStatus === AvailabilityStatusEnum.Unavailable"
+                [class.code-success]="availabilityStatus === AvailabilityStatusEnum.Available"
+                [class.code-dark]="availabilityStatus === AvailabilityStatusEnum.Unknown"
+          >{{ availabilityStatus }}</span>
+
+          @if (availabilityError) {
+            <div class="alert alert-danger m-0 mt-2 mb-2">{{ availabilityError }}</div>
+          }
+
+          <div class="row mt-5">
+            <div class="col-12 d-grid">
+              <button class="btn btn-outline-primary d-block" (click)="checkAvailability()">Check availability</button>
+            </div>
+          </div>
+        </div>
+      </app-card>
+    </div>
+
+    <div class="col-12 col-xl-6">
+      <app-card [status]="embedStatus">
+        <div header><h3 class="m-0">Embed</h3></div>
+        <div class="card-body">
+          <h5>Code</h5>
+          <code-editor [code]="embedCode" [readonly]="true" [height]="'400px'"></code-editor>
+
+          <div class="row mt-5">
+            <div class="col-12 d-grid">
+              <button class="btn btn-primary d-block" (click)="embed()">Embed</button>
+            </div>
+          </div>
+        </div>
+      </app-card>
+    </div>
+  </div>
+
+  <h2 class="display-6 mt-5"><i class="bi bi-journal-code"></i> API Reference</h2>
+  <hr>
+
+  <p class="text-muted">Based on the
+    <a href="https://github.com/explainers-by-googlers/semantic-embedder-api" target="_blank">Semantic Embedder API
+      explainer</a>. No WebIDL has been published yet, so the shapes below describe the surface as documented in the
+    explainer.</p>
+
+  <div class="row">
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header">
+          <h4 class="m-0"><span class="code">SemanticEmbedder.availability()</span></h4>
+        </div>
+        <div class="card-body">
+          <p>Static. Reports whether the on-device embedding model can be used, following the standard Built-in AI
+            lifecycle.</p>
+          <code-editor [code]="'SemanticEmbedder.availability(): Promise<Availability>'" [readonly]="true"
+                       [height]="'60px'"></code-editor>
+          <table class="table mt-3">
+            <thead>
+            <tr>
+              <th>Value</th>
+              <th>Meaning</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td><span class="code">"unavailable"</span></td>
+              <td>The model cannot be used on this device.</td>
+            </tr>
+            <tr>
+              <td><span class="code">"downloadable"</span></td>
+              <td>Supported, but the model must be downloaded first.</td>
+            </tr>
+            <tr>
+              <td><span class="code">"downloading"</span></td>
+              <td>The model is currently being downloaded.</td>
+            </tr>
+            <tr>
+              <td><span class="code">"available"</span></td>
+              <td>Ready to use immediately.</td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header">
+          <h4 class="m-0"><span class="code">SemanticEmbedder.create()</span></h4>
+        </div>
+        <div class="card-body">
+          <p>Static. Creates an embedder, downloading the model if needed.</p>
+          <code-editor
+            [code]="'SemanticEmbedder.create(options?: {\n  monitor?: (m: EventTarget) => void,\n  signal?: AbortSignal,\n}): Promise<SemanticEmbedder>'"
+            [readonly]="true" [height]="'110px'"></code-editor>
+          <table class="table mt-3">
+            <thead>
+            <tr>
+              <th>Option</th>
+              <th>Description</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td><span class="code">monitor</span></td>
+              <td>Receives an object emitting <span class="code">downloadprogress</span> events with a
+                <span class="code">loaded</span> ratio between 0 and 1.
+              </td>
+            </tr>
+            <tr>
+              <td><span class="code">signal</span></td>
+              <td>An <span class="code">AbortSignal</span> aborting the creation and the download.</td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header">
+          <h4 class="m-0"><span class="code">semanticEmbedder.embed()</span></h4>
+        </div>
+        <div class="card-body">
+          <p>Polymorphic: accepts a single string or an array of strings. The returned embeddings correspond strictly
+            1:1 with the inputs, in order.</p>
+          <code-editor
+            [code]="'semanticEmbedder.embed(\n  input: string | string[],\n  options?: {\n    taskType?: \'retrieval\' | \'classification\',\n    signal?: AbortSignal,\n  },\n): Promise<EmbedderResult>'"
+            [readonly]="true" [height]="'160px'"></code-editor>
+          <table class="table mt-3">
+            <thead>
+            <tr>
+              <th>Option</th>
+              <th>Description</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr>
+              <td><span class="code">taskType</span></td>
+              <td>Optional hint used to optimize embedding quality for a downstream task (e.g. retrieval,
+                classification). Browsers may ignore it.
+              </td>
+            </tr>
+            <tr>
+              <td><span class="code">signal</span></td>
+              <td>An <span class="code">AbortSignal</span> aborting the inference.</td>
+            </tr>
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header">
+          <h4 class="m-0"><span class="code">semanticEmbedder.destroy()</span></h4>
+        </div>
+        <div class="card-body">
+          <p>Proactively releases the resources held by the embedder. Call it as soon as you are done embedding: the
+            model consumes a significant amount of memory.</p>
+          <code-editor [code]="'semanticEmbedder.destroy(): void'" [readonly]="true" [height]="'60px'"></code-editor>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header">
+          <h4 class="m-0"><span class="code">EmbedderResult</span></h4>
+        </div>
+        <div class="card-body">
+          <p>A dictionary rather than a raw array, so the API can gain statistics, truncation warnings or multi-modal
+            metadata without breaking early adopters.</p>
+          <code-editor
+            [code]="'{\n  embeddings: [\n    {\n      values: Float32Array,\n      statistics: { tokenCount, truncated },\n    },\n  ],\n  metadata: {\n    embeddingSpace: \'embeddinggemma-300m\',\n    maxInputTokens: 2048,\n  },\n}'"
+            [readonly]="true" [height]="'220px'"></code-editor>
+          <p class="mt-3"><span class="code">statistics</span> and <span class="code">metadata</span> are described in
+            the explainer as extensibility points and may not be populated by early implementations.</p>
+        </div>
+      </div>
+    </div>
+
+    <div class="col-12 col-xl-6">
+      <div class="card mt-3">
+        <div class="card-header">
+          <h4 class="m-0">Limitations &amp; gotchas</h4>
+        </div>
+        <div class="card-body">
+          <ul class="mb-0">
+            <li><strong>No chunking.</strong> The API does not split large inputs. Pre-chunk documents yourself (e.g.
+              with LangChain's <span class="code">RecursiveCharacterTextSplitter</span>) to stay within the 2048-token
+              limit, and pass the passages as an array.
+            </li>
+            <li class="mt-2"><strong>No built-in comparison.</strong> Cosine similarity is up to you (or a third-party
+              library). A static <span class="code">SemanticEmbedder.compare()</span> is under discussion.
+            </li>
+            <li class="mt-2"><strong>No storage.</strong> There is no built-in vector database: persist vectors in
+              IndexedDB or OPFS.
+            </li>
+            <li class="mt-2"><strong>Embedding spaces are not interchangeable.</strong> Vectors produced by different
+              models cannot be compared; re-index when the embedding space changes.
+            </li>
+            <li class="mt-2"><strong>Permissions policy.</strong> Access is restricted to top-level frames and
+              same-origin iframes by default; third-party contexts must be granted access explicitly.
+            </li>
+            <li class="mt-2"><strong>Naming is an open question.</strong> <span class="code">SemanticEmbedder</span> is
+              the name chosen for the developer trial, over <span class="code">TextEmbedder</span> and
+              <span class="code">FeatureExtractor</span>.
+            </li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.ts
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.ts
@@ -1,0 +1,292 @@
+import {Component, DOCUMENT, Inject, OnInit, PLATFORM_ID} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
+import {FormControl} from '@angular/forms';
+import {ActivatedRoute, Router} from '@angular/router';
+import {Title} from '@angular/platform-browser';
+
+import {BaseBuiltInApiPageComponent} from '../../../components/base/base-built-in-api-page.component';
+import {AvailabilityStatusEnum} from '../../../enums/availability-status.enum';
+import {BuiltInAiApiEnum} from '../../../enums/built-in-ai-api.enum';
+import {RequirementStatus} from '../../../enums/requirement-status.enum';
+import {SemanticEmbedderTaskTypeEnum} from '../../../enums/semantic-embedder-task-type.enum';
+import {TaskStatus} from '../../../enums/task-status.enum';
+import {RequirementInterface} from '../../../interfaces/requirement.interface';
+import {ExecutionPerformanceManager} from '../../../managers/execution-performance.manager';
+import {EmbedderMetadataInterface} from './interfaces/embedder-metadata.interface';
+import {EmbedderResultInterface} from './interfaces/embedder-result.interface';
+import {EmbeddingRowInterface} from './interfaces/embedding-row.interface';
+
+@Component({
+  selector: 'app-semantic-embedder-api',
+  templateUrl: './semantic-embedder-api.component.html',
+  standalone: false,
+  styleUrl: './semantic-embedder-api.component.scss'
+})
+export class SemanticEmbedderApiComponent extends BaseBuiltInApiPageComponent implements OnInit {
+
+  public apiFlag: RequirementInterface = {
+    status: RequirementStatus.Pending,
+    message: 'Pending',
+    contentHtml: `Activate <span class="code">chrome://flags/#semantic-embedder-api</span>`,
+  }
+
+  embedStatus = TaskStatus.Idle;
+
+  availabilityTaskStatus = TaskStatus.Idle;
+
+  /**
+   * One passage per line. The API does not chunk large inputs, so the developer is the one
+   * splitting the document into passages.
+   */
+  inputFormControl = new FormControl<string>(`The quick brown fox jumps over the lazy dog.
+A fast, dark-colored fox leaps over a resting hound.
+Built-in AI APIs use on-device models.`);
+
+  taskTypeFormControl = new FormControl<SemanticEmbedderTaskTypeEnum | null>(null);
+
+  rows: EmbeddingRowInterface[] = [];
+
+  metadata?: EmbedderMetadataInterface;
+
+  /**
+   * Cosine similarity of every embedding against every other embedding.
+   */
+  similarityMatrix: number[][] = [];
+
+  /**
+   * Number of values of each vector displayed in the preview column.
+   */
+  previewLength = 8;
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId: Object,
+    @Inject(DOCUMENT) document: Document,
+    route: ActivatedRoute,
+    router: Router,
+    title: Title,
+    public readonly executionPerformanceManager: ExecutionPerformanceManager,
+  ) {
+    super(document, title, router, route);
+  }
+
+  override ngOnInit() {
+    super.ngOnInit();
+
+    this.setTitle('Semantic Embedder API | AI Playground');
+
+    this.checkRequirements();
+    this.executionPerformanceManager.reset();
+
+    this.subscriptions.push(this.route.queryParams.subscribe((params) => {
+      if (params['input']) {
+        this.inputFormControl.setValue(params['input'], {emitEvent: false});
+      }
+
+      if (params['taskType']) {
+        this.taskTypeFormControl.setValue(params['taskType'], {emitEvent: false});
+      }
+    }));
+
+    this.subscriptions.push(this.inputFormControl.valueChanges.subscribe((value) => {
+      this.router.navigate(['.'], {
+        relativeTo: this.route,
+        queryParams: {input: value},
+        queryParamsHandling: 'merge'
+      });
+    }));
+
+    this.subscriptions.push(this.taskTypeFormControl.valueChanges.subscribe((value) => {
+      this.router.navigate(['.'], {
+        relativeTo: this.route,
+        queryParams: {taskType: value},
+        queryParamsHandling: 'merge'
+      });
+    }));
+  }
+
+  checkRequirements() {
+    if (isPlatformBrowser(this.platformId) && (!this.window || !("SemanticEmbedder" in this.window))) {
+      this.apiFlag.status = RequirementStatus.Fail;
+      this.apiFlag.message = "'SemanticEmbedder' is not defined. Activate the flag.";
+    } else if (isPlatformBrowser(this.platformId)) {
+      this.apiFlag.status = RequirementStatus.Pass;
+      this.apiFlag.message = "Passed";
+    }
+  }
+
+  getRequirements(): RequirementInterface[] {
+    return [this.apiFlag];
+  }
+
+  /**
+   * Splits the textarea into the array of passages passed to `embed()`. Empty lines are dropped.
+   */
+  getInputs(): string[] {
+    return (this.inputFormControl.value ?? "")
+      .split("\n")
+      .map(line => line.trim())
+      .filter(line => line.length > 0);
+  }
+
+  get availabilityCode(): string {
+    return `const availability = await SemanticEmbedder.availability();`;
+  }
+
+  async checkAvailability() {
+    try {
+      this.availabilityTaskStatus = TaskStatus.Executing;
+      this.availabilityError = undefined;
+
+      // @ts-expect-error SemanticEmbedder is not yet part of the TypeScript DOM lib.
+      this.availabilityStatus = await SemanticEmbedder.availability();
+
+      this.availabilityTaskStatus = TaskStatus.Completed;
+    } catch (e: unknown) {
+      this.availabilityError = e as Error;
+      this.availabilityStatus = AvailabilityStatusEnum.Unavailable;
+      this.availabilityTaskStatus = TaskStatus.Error;
+    }
+  }
+
+  get embedCode(): string {
+    const inputs = this.getInputs();
+    const taskType = this.taskTypeFormControl.value;
+
+    return `const abortController = new AbortController();
+
+const semanticEmbedder = await SemanticEmbedder.create({
+  monitor(m) {
+    m.addEventListener("downloadprogress", (e) => {
+      console.log(\`Downloaded \${e.loaded * 100}%\`);
+    });
+  },
+  signal: abortController.signal,
+});
+
+// The API does not chunk large inputs: pass an array of pre-chunked passages instead.
+const result = await semanticEmbedder.embed(${JSON.stringify(inputs, null, 2)}${taskType ? `, {
+  taskType: ${JSON.stringify(taskType)},
+}` : ``});
+
+// result.embeddings[i].values is a Float32Array matching inputs[i].
+const vectors = result.embeddings.map(embedding => embedding.values);
+
+// Release the model as soon as you are done with it.
+semanticEmbedder.destroy();`;
+  }
+
+  async embed() {
+    const inputs = this.getInputs();
+
+    if (inputs.length === 0) {
+      return;
+    }
+
+    this.outputCollapsed = false;
+    this.embedStatus = TaskStatus.Executing;
+    this.error = undefined;
+    this.rows = [];
+    this.similarityMatrix = [];
+    this.metadata = undefined;
+
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const self = this;
+
+    let semanticEmbedder: {
+      embed: (input: string | string[], options?: object) => Promise<EmbedderResultInterface>,
+      destroy: () => void,
+    } | undefined;
+
+    try {
+      this.abortControllerFromCreate = new AbortController();
+      this.abortController = new AbortController();
+
+      this.executionPerformanceManager.start(BuiltInAiApiEnum.SemanticEmbedder);
+      this.executionPerformanceManager.sessionCreationStarted();
+
+      // @ts-expect-error SemanticEmbedder is not yet part of the TypeScript DOM lib.
+      semanticEmbedder = await SemanticEmbedder.create({
+        monitor(m: EventTarget) {
+          m.addEventListener("downloadprogress", (e: Event) => {
+            self.loaded = (e as Event & { loaded: number }).loaded;
+            self.executionPerformanceManager.downloadUpdated(self.loaded);
+          });
+        },
+        signal: this.abortControllerFromCreate.signal,
+      });
+      this.executionPerformanceManager.sessionCreationCompleted();
+
+      this.executionPerformanceManager.inferenceStarted({input: inputs.join("\n")});
+
+      const taskType = this.taskTypeFormControl.value;
+      const result = await semanticEmbedder!.embed(inputs, {
+        ...(taskType ? {taskType} : {}),
+        signal: this.abortController.signal,
+      });
+      this.executionPerformanceManager.tokenReceived();
+
+      this.metadata = result.metadata;
+      this.rows = result.embeddings.map((embedding, index) => ({
+        index,
+        input: inputs[index],
+        dimensions: embedding.values.length,
+        tokenCount: embedding.statistics?.tokenCount,
+        truncated: embedding.statistics?.truncated,
+        values: Array.from(embedding.values),
+      }));
+
+      this.similarityMatrix = this.computeSimilarityMatrix(this.rows);
+
+      this.output = `${this.rows.length} embedding(s) of ${this.rows[0]?.dimensions ?? 0} dimensions generated.`;
+
+      this.embedStatus = TaskStatus.Completed;
+    } catch (e: unknown) {
+      this.error = e as Error;
+      this.embedStatus = TaskStatus.Error;
+      this.executionPerformanceManager.sessionCreationCompleted();
+    } finally {
+      this.executionPerformanceManager.inferenceCompleted();
+
+      // The embedder holds on to the model: release it proactively.
+      semanticEmbedder?.destroy();
+    }
+  }
+
+  computeSimilarityMatrix(rows: EmbeddingRowInterface[]): number[][] {
+    return rows.map(rowA => rows.map(rowB => this.computeCosineSimilarity(rowA.values, rowB.values)));
+  }
+
+  computeCosineSimilarity(vectorA: number[], vectorB: number[]): number {
+    let dotProduct = 0;
+    let normA = 0;
+    let normB = 0;
+
+    for (let i = 0; i < vectorA.length; i++) {
+      dotProduct += vectorA[i] * vectorB[i];
+      normA += vectorA[i] * vectorA[i];
+      normB += vectorB[i] * vectorB[i];
+    }
+
+    const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+
+    return denominator === 0 ? 0 : dotProduct / denominator;
+  }
+
+  getPreview(row: EmbeddingRowInterface): string {
+    const preview = row.values.slice(0, this.previewLength).map(value => value.toFixed(4)).join(", ");
+
+    return `[${preview}${row.values.length > this.previewLength ? ", …" : ""}]`;
+  }
+
+  abortTriggered() {
+    console.log(`abortTriggered`);
+    this.abortController?.abort();
+  }
+
+  abortFromCreateTriggered() {
+    console.log(`abortFromCreateTriggered`);
+    this.abortControllerFromCreate?.abort();
+  }
+
+  protected readonly SemanticEmbedderTaskTypeEnum = SemanticEmbedderTaskTypeEnum;
+}

--- a/src/app/pages/index/index.page.html
+++ b/src/app/pages/index/index.page.html
@@ -20,6 +20,8 @@
           Rewriter API</a></li>
         <li class="mt-3"><a class="btn btn-light" routerLink="prompt-api"><i class="bi bi-input-cursor-text"></i> Prompt
           API</a></li>
+        <li class="mt-3"><a class="btn btn-light" routerLink="semantic-embedder-api"><i class="bi bi-diagram-3"></i>
+          Semantic Embedder API</a></li>
       </ul>
     </div>
   </div>

--- a/src/app/pages/performance/performance-history/performance-history.page.html
+++ b/src/app/pages/performance/performance-history/performance-history.page.html
@@ -24,6 +24,9 @@
               @case (BuiltInAiApiEnum.Rewriter) {
                  <h6><i class="bi bi-arrow-clockwise"></i> Rewriter</h6>
               }
+              @case (BuiltInAiApiEnum.SemanticEmbedder) {
+                 <h6><i class="bi bi-diagram-3"></i> Semantic Embedder</h6>
+              }
               @case (BuiltInAiApiEnum.Summarizer) {
                  <h6><i class="bi bi-text-paragraph"></i> Summarizer</h6>
               }


### PR DESCRIPTION
Integrates the proposed [Semantic Embedder API](https://github.com/explainers-by-googlers/semantic-embedder-api) into the playground, following the `availability()` → `create()` → `embed()` pattern used by the other Built-In AI API pages.

## Playground

- Batch input: one passage per line, sent as a single `embed()` call — the API does not chunk large inputs, so pre-chunking is the developer's job.
- Optional `taskType` hint (`retrieval` / `classification`), which browsers may ignore.
- `create()` with a download `monitor` and `AbortSignal`, `embed()` with an `AbortSignal`, and `destroy()` in a `finally` to release the model.
- Results: embeddings table (dimensions, token count, truncation badge, first 8 values), a full cosine-similarity matrix computed in JS, and `metadata.embeddingSpace` / `maxInputTokens` when present.
- Input and task type sync to query params; execution is tracked through `ExecutionPerformanceManager`.

## API Reference

New section documenting `SemanticEmbedder.availability()` (with the current `unavailable` / `downloadable` / `downloading` / `available` values), `create()`, `embed()`, `destroy()`, the `EmbedderResult` shape, plus a limitations card (no chunking, no built-in comparison, no storage, embedding-space incompatibility, permissions policy, naming open question).

## Wiring

`RouteEnum`, `BuiltInAiApiEnum`, `AppRoutingModule`, `AppModule` declarations, sidebar entry (with `setCurrentRoute()`), home page list, and the performance-history label.

## Notes

- The flag name `chrome://flags/#semantic-embedder-api` in the requirements block is a guess — the explainer does not name one. Worth swapping once the DevTrial flag is known.
- `SemanticEmbedderTaskTypeEnum` only contains `retrieval` and `classification`, the two values the explainer names. No WebIDL has been published, so the documented shapes follow the explainer prose.
- `npm run build` passes. The prerender warnings it emits are pre-existing on `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)