### PR TITLE
Fix the errors masking session failures on the Semantic Embedder page

### DIFF
--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.ts
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.ts
@@ -197,12 +197,28 @@ semanticEmbedder.destroy();`;
       destroy: () => void,
     } | undefined;
 
+    // The performance manager measures against the marks set by its `*Started()` methods: calling a
+    // `*Completed()` method for a step that never started throws a SyntaxError that masks the real
+    // error.
+    let sessionCreationStarted = false;
+    let inferenceStarted = false;
+
     try {
       this.abortControllerFromCreate = new AbortController();
       this.abortController = new AbortController();
 
+      // `create()` throws an opaque InvalidStateError when the model is not usable on this device,
+      // so check the availability first to be able to report something actionable.
+      // @ts-expect-error SemanticEmbedder is not yet part of the TypeScript DOM lib.
+      this.availabilityStatus = await SemanticEmbedder.availability();
+
+      if (this.availabilityStatus === AvailabilityStatusEnum.Unavailable) {
+        throw new Error("SemanticEmbedder.availability() returned 'unavailable': the embedding model cannot run on this device.");
+      }
+
       this.executionPerformanceManager.start(BuiltInAiApiEnum.SemanticEmbedder);
       this.executionPerformanceManager.sessionCreationStarted();
+      sessionCreationStarted = true;
 
       // @ts-expect-error SemanticEmbedder is not yet part of the TypeScript DOM lib.
       semanticEmbedder = await SemanticEmbedder.create({
@@ -215,8 +231,10 @@ semanticEmbedder.destroy();`;
         signal: this.abortControllerFromCreate.signal,
       });
       this.executionPerformanceManager.sessionCreationCompleted();
+      sessionCreationStarted = false;
 
       this.executionPerformanceManager.inferenceStarted({input: inputs.join("\n")});
+      inferenceStarted = true;
 
       const taskType = this.taskTypeFormControl.value;
       const result = await semanticEmbedder!.embed(inputs, {
@@ -243,9 +261,14 @@ semanticEmbedder.destroy();`;
     } catch (e: unknown) {
       this.error = e as Error;
       this.embedStatus = TaskStatus.Error;
-      this.executionPerformanceManager.sessionCreationCompleted();
+
+      if (sessionCreationStarted) {
+        this.executionPerformanceManager.sessionCreationCompleted();
+      }
     } finally {
-      this.executionPerformanceManager.inferenceCompleted();
+      if (inferenceStarted) {
+        this.executionPerformanceManager.inferenceCompleted();
+      }
 
       // The embedder holds on to the model: release it proactively.
       semanticEmbedder?.destroy();


### PR DESCRIPTION
Two errors were showing up on the Semantic Embedder page, and the second one was hiding the first.

## `SyntaxError: The mark 'INFERENCE_STARTED' does not exist`

`embed()` called `executionPerformanceManager.inferenceCompleted()` from its `finally` block unconditionally. When `create()` failed, `inferenceStarted()` had never run, so `InferencePerformanceManager.inferenceCompleted()` measured against a mark that was never set and threw — **from the `finally`**, which replaced the original error and made the real failure impossible to read.

Now the page tracks whether each step actually started and only calls the matching `*Completed()` method. The same guard is applied to `sessionCreationCompleted()` in the `catch`.

## `InvalidStateError: The device is unable to create a session to run the model`

This one is genuine: it comes from `SemanticEmbedder.create()` when the model isn't in a usable state on the device. `embed()` now calls `availability()` first, stores the result (so it also surfaces in the Availability card) and throws a legible error when it is `unavailable`, instead of letting `create()` fail opaquely.

Note this is unrelated to `taskType`: the explainer describes it as "strictly an optional hint that browsers can safely ignore", and it is an option to `embed()`, not `create()`.

## Notes

- `npm run build` passes.
- Branched off `master`, so it does not include #49 (the API Reference removal). Different files, no conflict.
- The same unguarded `inferenceCompleted()` in a `finally` exists on other pages (`language-detector.component.ts` at least). Not touched here — worth a separate sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)