### PR TITLE
Document the on-disk model location on the Semantic Embedder page

### DIFF
--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.html
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.html
@@ -21,6 +21,109 @@
             has not been approved to ship in Chrome. The surface below follows the explainer and may change.</p>
           <p class="mt-1">Embeddings are only comparable within the same embedding space: check
             <span class="code">result.metadata.embeddingSpace</span> before comparing vectors you stored earlier.</p>
+
+          <h5 class="mt-4">Where the model is downloaded on disk</h5>
+          <p>Once the embedding model has been downloaded, it is stored under the Chrome user data directory in an
+            <span class="code">AIEmbeddings</span> folder, inside a version-numbered sub-folder (for example
+            <span class="code">2026.5.19.1005</span>), as <span class="code">model.tflite</span>. Checking that this
+            file exists is the quickest way to confirm the download actually completed.</p>
+          <p>The version folder changes as Chrome ships new model revisions, and you may have more than one of them.
+            The paths below differ per <strong>release channel</strong> — Stable, Beta, Dev and Canary each keep their
+            own copy of the model, so make sure you are looking at the directory of the channel you are actually
+            running.</p>
+
+          <h6 class="mt-3">macOS</h6>
+          <div style="max-height: 400px; overflow: auto">
+            <table class="table table-responsive">
+              <thead>
+              <tr>
+                <th>Channel</th>
+                <th>Path</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>Stable</td>
+                <td><span class="code">~/Library/Application Support/Google/Chrome/AIEmbeddings/&lt;version&gt;/model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Beta</td>
+                <td><span class="code">~/Library/Application Support/Google/Chrome Beta/AIEmbeddings/&lt;version&gt;/model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Dev</td>
+                <td><span class="code">~/Library/Application Support/Google/Chrome Dev/AIEmbeddings/&lt;version&gt;/model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Canary</td>
+                <td><span class="code">~/Library/Application Support/Google/Chrome Canary/AIEmbeddings/&lt;version&gt;/model.tflite</span></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h6 class="mt-3">Windows</h6>
+          <div style="max-height: 400px; overflow: auto">
+            <table class="table table-responsive">
+              <thead>
+              <tr>
+                <th>Channel</th>
+                <th>Path</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>Stable</td>
+                <td><span class="code">%LOCALAPPDATA%\Google\Chrome\User Data\AIEmbeddings\&lt;version&gt;\model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Beta</td>
+                <td><span class="code">%LOCALAPPDATA%\Google\Chrome Beta\User Data\AIEmbeddings\&lt;version&gt;\model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Dev</td>
+                <td><span class="code">%LOCALAPPDATA%\Google\Chrome Dev\User Data\AIEmbeddings\&lt;version&gt;\model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Canary</td>
+                <td><span class="code">%LOCALAPPDATA%\Google\Chrome SxS\User Data\AIEmbeddings\&lt;version&gt;\model.tflite</span></td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <h6 class="mt-3">Linux</h6>
+          <div style="max-height: 400px; overflow: auto">
+            <table class="table table-responsive">
+              <thead>
+              <tr>
+                <th>Channel</th>
+                <th>Path</th>
+              </tr>
+              </thead>
+              <tbody>
+              <tr>
+                <td>Stable</td>
+                <td><span class="code">~/.config/google-chrome/AIEmbeddings/&lt;version&gt;/model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Beta</td>
+                <td><span class="code">~/.config/google-chrome-beta/AIEmbeddings/&lt;version&gt;/model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Dev</td>
+                <td><span class="code">~/.config/google-chrome-unstable/AIEmbeddings/&lt;version&gt;/model.tflite</span></td>
+              </tr>
+              <tr>
+                <td>Canary</td>
+                <td>Chrome Canary is not available on Linux — use Dev instead.</td>
+              </tr>
+              </tbody>
+            </table>
+          </div>
+
+          <p class="mt-3">If you launch Chrome with a custom <span class="code">--user-data-dir</span>, the
+            <span class="code">AIEmbeddings</span> folder lives under that directory instead of the defaults above.</p>
         </div>
       </app-page-accordion>
     </div>


### PR DESCRIPTION
## Summary

Adds a **"Where the model is downloaded on disk"** section to the debug information panel of the Semantic Embedder API page, so it's easy to verify whether the embedding model actually finished downloading.

- Explains that the model lands in `AIEmbeddings/<version>/model.tflite` under the Chrome user data directory, in a version-numbered sub-folder (e.g. `2026.5.19.1005`).
- Makes it explicit that **Stable, Beta, Dev and Canary each keep their own copy**, so you have to look at the directory of the channel you're actually running.
- One table per platform:
  - **macOS** — `~/Library/Application Support/Google/Chrome[ Beta| Dev| Canary]/AIEmbeddings/<version>/model.tflite`
  - **Windows** — `%LOCALAPPDATA%\Google\Chrome[ Beta| Dev| SxS]\User Data\AIEmbeddings\<version>\model.tflite` (Canary is `Chrome SxS`)
  - **Linux** — `~/.config/google-chrome[-beta|-unstable]/AIEmbeddings/<version>/model.tflite`, with Canary noted as unavailable on Linux
- Closing note that a custom `--user-data-dir` relocates the folder.

## Notes

The macOS Canary path is the one observed directly; the other channels and platforms were derived from the standard Chrome user-data-dir layout. Worth a sanity check that the Windows path is at the `User Data` root rather than profile-scoped (`User Data\Default\...`).

## Test plan

- [x] `ng build --configuration development` succeeds. The `does not have the key 'value'` / `window is not defined` prerender messages in the output are pre-existing on `master` and unrelated.
- [ ] Visually check the debug accordion on the Semantic Embedder page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)