### PR TITLE
Fix the .code styling in dark mode and color code the similarity matrix

### DIFF
--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.html
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.html
@@ -100,13 +100,29 @@
               <tr>
                 <th>#{{ row.index }}</th>
                 @for (similarity of similarityMatrix[row.index]; track $index) {
-                  <td>{{ similarity | number: '1.4-4' }}</td>
+                  <td>
+                    <span [class]="'similarity ' + getSimilarityClass(similarity)">{{ similarity | number: '1.4-4' }}</span>
+                  </td>
                 }
               </tr>
             }
           </tbody>
         </table>
       </div>
+
+      <div class="d-flex flex-wrap gap-2 align-items-center mt-2">
+        <small class="text-muted">Legend:</small>
+        <span class="similarity similarity-very-high">≥ 0.85</span>
+        <small class="text-muted me-2">near-duplicate</small>
+        <span class="similarity similarity-high">≥ 0.65</span>
+        <small class="text-muted me-2">related</small>
+        <span class="similarity similarity-moderate">≥ 0.45</span>
+        <small class="text-muted me-2">loosely related</small>
+        <span class="similarity similarity-low">&lt; 0.45</span>
+        <small class="text-muted">unrelated</small>
+      </div>
+      <p class="text-muted mt-2"><small>These thresholds are a reading aid, not a property of the API: the meaningful
+        cut-off depends on the embedding space and on your task, so calibrate them on your own data.</small></p>
     }
   </app-output>
 

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.scss
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.scss
@@ -1,0 +1,44 @@
+// Every color below is read from a Bootstrap CSS variable so that the cells follow the active
+// `data-bs-theme` instead of being locked to the light palette.
+.similarity {
+  display: inline-block;
+  min-width: 4.5rem;
+  padding: 2px 6px;
+  border-radius: 6px;
+  text-align: right;
+  // Keeps the digits aligned from one row to the next so the matrix reads as a grid.
+  font-variant-numeric: tabular-nums;
+  background-color: var(--bs-secondary-bg-subtle);
+  border: 1px solid var(--bs-secondary-border-subtle);
+  color: var(--bs-secondary-text-emphasis);
+
+  &.similarity-very-high {
+    background-color: var(--bs-success-bg-subtle);
+    border-color: var(--bs-success-border-subtle);
+    color: var(--bs-success-text-emphasis);
+  }
+
+  &.similarity-high {
+    background-color: var(--bs-info-bg-subtle);
+    border-color: var(--bs-info-border-subtle);
+    color: var(--bs-info-text-emphasis);
+  }
+
+  &.similarity-moderate {
+    background-color: var(--bs-warning-bg-subtle);
+    border-color: var(--bs-warning-border-subtle);
+    color: var(--bs-warning-text-emphasis);
+  }
+
+  &.similarity-low {
+    background-color: var(--bs-danger-bg-subtle);
+    border-color: var(--bs-danger-border-subtle);
+    color: var(--bs-danger-text-emphasis);
+  }
+}
+
+// The vector previews are long single tokens: let them wrap inside their cell instead of forcing
+// the table to scroll horizontally on narrow viewports.
+td .code {
+  overflow-wrap: anywhere;
+}

--- a/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.ts
+++ b/src/app/pages/built-in-ai-apis/semantic-embedder-api/semantic-embedder-api.component.ts
@@ -295,6 +295,39 @@ semanticEmbedder.destroy();`;
     return denominator === 0 ? 0 : dotProduct / denominator;
   }
 
+  /**
+   * Thresholds used to color code the cosine similarity matrix. They are a reading aid, not a
+   * property of the API: the useful cut-off depends on the embedding space and on the task, so
+   * calibrate them on your own data before relying on them to accept or reject a match.
+   */
+  static readonly similarityThresholds = {
+    veryHigh: 0.85,
+    high: 0.65,
+    moderate: 0.45,
+  };
+
+  /**
+   * Maps a cosine similarity to the CSS class tinting its cell, from green (near-duplicate) to red
+   * (unrelated). Negative values fall in the lowest band.
+   */
+  getSimilarityClass(similarity: number): string {
+    const thresholds = SemanticEmbedderApiComponent.similarityThresholds;
+
+    if (similarity >= thresholds.veryHigh) {
+      return "similarity-very-high";
+    }
+
+    if (similarity >= thresholds.high) {
+      return "similarity-high";
+    }
+
+    if (similarity >= thresholds.moderate) {
+      return "similarity-moderate";
+    }
+
+    return "similarity-low";
+  }
+
   getPreview(row: EmbeddingRowInterface): string {
     const preview = row.values.slice(0, this.previewLength).map(value => value.toFixed(4)).join(", ");
 

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -3,31 +3,35 @@
 @import "bootstrap/scss/functions";
 @import "bootstrap/scss/variables";
 
+// The subtle colors are read from the Bootstrap CSS variables rather than from the Sass variables:
+// the Sass values are baked in at compile time and always resolve to the light theme, which leaves
+// light text on a light background once `data-bs-theme="dark"` is set. The CSS variables follow the
+// active theme.
 .code {
-  background-color: $primary-bg-subtle;
-  border: 1px solid $primary-border-subtle;
+  background-color: var(--bs-primary-bg-subtle);
+  border: 1px solid var(--bs-primary-border-subtle);
   padding: 3px;
   border-radius: 6px;
 
   &.code-warning {
-    background-color: $warning-bg-subtle;
-    border: 1px solid $warning-border-subtle;
+    background-color: var(--bs-warning-bg-subtle);
+    border: 1px solid var(--bs-warning-border-subtle);
   }
   &.code-info {
-    background-color: $info-bg-subtle;
-    border: 1px solid $info-border-subtle;
+    background-color: var(--bs-info-bg-subtle);
+    border: 1px solid var(--bs-info-border-subtle);
   }
   &.code-success {
-    background-color: $success-bg-subtle;
-    border: 1px solid $success-border-subtle;
+    background-color: var(--bs-success-bg-subtle);
+    border: 1px solid var(--bs-success-border-subtle);
   }
   &.code-danger {
-    background-color: $danger-bg-subtle;
-    border: 1px solid $danger-border-subtle;
+    background-color: var(--bs-danger-bg-subtle);
+    border: 1px solid var(--bs-danger-border-subtle);
   }
   &.code-dark {
-    background-color: $dark-bg-subtle;
-    border: 1px solid $dark-border-subtle;
+    background-color: var(--bs-dark-bg-subtle);
+    border: 1px solid var(--bs-dark-border-subtle);
   }
 }
 


### PR DESCRIPTION
## Dark mode

The `.code` class in `src/styles.scss` was built from the Bootstrap **Sass** variables (`$primary-bg-subtle`, …). Those are resolved at compile time and always yield the light palette, so under `data-bs-theme="dark"` you got the light body text on a pale-blue background. The Semantic Embedder page shows it worst because its output is almost entirely `.code` spans.

Swapped all six variants to the equivalent Bootstrap **CSS** variables (`var(--bs-primary-bg-subtle)`, …), which Bootstrap redefines under `[data-bs-theme=dark]` — verified against `node_modules/bootstrap/dist/css/bootstrap.css` (e.g. `--bs-primary-bg-subtle: #031633` in dark). The light-mode values are identical to the Sass ones, so light mode is unchanged.

Note this is a **global** fix rather than a page-local patch: `.code` is used on every API page, so they all get correct dark mode.

Left `code-editor.component.scss` alone even though it hardcodes `#cfe2ff` / `#E8F0FE` / `white`. It stays legible in dark mode (dark Ace syntax colors on a light background), so it is a look-and-feel mismatch rather than a readability bug, and changing it means also switching the Ace theme.

## Color-coded similarity

- `getSimilarityClass()` maps each cosine similarity to one of four bands, with the thresholds exposed as a static `similarityThresholds`: ≥ 0.85 green (near-duplicate), ≥ 0.65 blue (related), ≥ 0.45 amber (loosely related), below that red (unrelated). Negative values fall in the lowest band.
- Matrix cells render the number in a tinted pill styled from the same theme-aware CSS variables, plus `*-text-emphasis` for the text, so the color coding is legible in both themes. `font-variant-numeric: tabular-nums` keeps the digits aligned into a grid.
- Added a legend under the matrix and a note that the thresholds are a reading aid to calibrate on your own data, not a property of the API.
- Minor: long vector previews now wrap inside their cell instead of forcing horizontal scroll on narrow viewports.

## Test plan

- [x] `ng build --configuration development` succeeds. The `does not have the key 'value'` prerender messages in the output are pre-existing on `master` and unrelated.
- [ ] **Not verified visually** — worth loading the page and flipping the theme toggle. The dark-mode result is reasoned from the Bootstrap variable definitions, not observed.

Independent of #51, which touches a different region of the same template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)