### PR TITLE
Update the Semantic Embedder task types to the five documented values

### DIFF
--- a/src/app/enums/semantic-embedder-task-type.enum.ts
+++ b/src/app/enums/semantic-embedder-task-type.enum.ts
@@ -2,13 +2,19 @@
  * Optional hint passed to `SemanticEmbedder.embed()` to let the underlying model optimize the
  * embedding for a specific downstream task.
  *
- * The explainer only names `retrieval` and `classification` explicitly and states that the hint is
- * strictly optional: a browser is allowed to ignore it entirely if its model doesn't support task
- * types.
+ * The hint is strictly optional: a browser is allowed to ignore it entirely if its model doesn't
+ * support task types.
+ *
+ * Retrieval is split in two: embed the query with `RetrievalQuery` and the passages it is matched
+ * against with `RetrievalDocument`. Using the same value on both sides is a common mistake and
+ * degrades the quality of the match.
  *
  * @see https://github.com/explainers-by-googlers/semantic-embedder-api#task-type-optimization-hints
  */
 export enum SemanticEmbedderTaskTypeEnum {
-  Retrieval = 'retrieval',
+  SemanticSimilarity = 'semantic-similarity',
+  RetrievalQuery = 'retrieval-query',
+  RetrievalDocument = 'retrieval-document',
   Classification = 'classification',
+  Clustering = 'clustering',
 }


### PR DESCRIPTION
## Summary

Corrects `SemanticEmbedderTaskTypeEnum` to the five actual task types:

```ts
SemanticSimilarity = 'semantic-similarity',
RetrievalQuery     = 'retrieval-query',
RetrievalDocument  = 'retrieval-document',
Classification     = 'classification',
Clustering         = 'clustering',
```

The enum previously had only `retrieval` and `classification`. `retrieval` is gone, replaced by the query/document split.

Nothing referenced the removed `Retrieval` member by name: the playground dropdown builds itself from the enum through the `keyvalue` pipe, and the selected value flows straight into `embed()` and into the generated code sample, so all three pick up the new values automatically.

The doc comment now spells out the query/document distinction — embed the query with `retrieval-query` and the passages it is matched against with `retrieval-document`. Using the same value on both sides is an easy mistake that quietly degrades the match.

## Notes

- Cosmetic side effect: `keyvalue` sorts by key, so the dropdown lists them alphabetically (Classification, Clustering, Retrieval document, Retrieval query, Semantic similarity) rather than in declaration order. Easy to pin with a `compareFn` if you would rather control the order.
- Options render as their raw values (`retrieval-query`, …) rather than human-readable labels, which is the behavior that was already there.

## Test plan

- [x] `ng build --configuration development` succeeds with no errors.
- [ ] Check the task type dropdown on the playground and confirm the value reaches `embed()` and the code sample.

Independent of #51 and #52 — different files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)